### PR TITLE
Add API token authentication and CORS protection

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -3,6 +3,9 @@
  *
  * Each function maps 1:1 to a FastAPI route in dashboard_api.py.
  * All responses are typed to match the Pydantic models (src/schemas.py).
+ *
+ * All /api/* requests include a per-instance auth token injected by the
+ * server into window.__DASHBOARD_TOKEN__ at page load.
  */
 
 import type {
@@ -14,16 +17,27 @@ import type {
   ServerInfo,
 } from "../types";
 
+/** Read the auth token injected by the server into the HTML page. */
+function getToken(): string {
+  return window.__DASHBOARD_TOKEN__ ?? "";
+}
+
+/** Append the auth token as a query parameter. */
+function withToken(url: string): string {
+  const sep = url.includes("?") ? "&" : "?";
+  return `${url}${sep}token=${encodeURIComponent(getToken())}`;
+}
+
 /** Generic GET helper — throws on non-2xx responses. */
 async function get<T>(url: string): Promise<T> {
-  const resp = await fetch(url);
+  const resp = await fetch(withToken(url));
   if (!resp.ok) throw new Error(`${resp.status} ${resp.statusText}`);
   return resp.json() as Promise<T>;
 }
 
 /** Generic POST helper — throws on non-2xx responses. */
 async function post<T>(url: string): Promise<T> {
-  const resp = await fetch(url, { method: "POST" });
+  const resp = await fetch(withToken(url), { method: "POST" });
   if (!resp.ok) throw new Error(`${resp.status} ${resp.statusText}`);
   return resp.json() as Promise<T>;
 }
@@ -91,7 +105,7 @@ export function fetchServerInfo(): Promise<ServerInfo> {
  */
 export async function triggerUpdate(): Promise<void> {
   try {
-    await fetch("/api/update", { method: "POST" });
+    await fetch(withToken("/api/update"), { method: "POST" });
   } catch {
     // Server dies mid-response during self-update — this is expected
   }

--- a/frontend/src/test/api.test.ts
+++ b/frontend/src/test/api.test.ts
@@ -34,32 +34,35 @@ function jsonResponse(data: unknown, status = 200) {
 }
 
 describe("API client", () => {
+  // Token is set in setup.ts as "test-token"
+  const T = "?token=test-token";
+
   describe("GET endpoints", () => {
     it("fetchSessions calls /api/sessions", async () => {
       mockFetch.mockReturnValue(jsonResponse([{ id: "abc" }]));
       const result = await fetchSessions();
-      expect(mockFetch).toHaveBeenCalledWith("/api/sessions");
+      expect(mockFetch).toHaveBeenCalledWith(`/api/sessions${T}`);
       expect(result).toEqual([{ id: "abc" }]);
     });
 
     it("fetchProcesses calls /api/processes", async () => {
       mockFetch.mockReturnValue(jsonResponse({ abc: { pid: 123 } }));
       const result = await fetchProcesses();
-      expect(mockFetch).toHaveBeenCalledWith("/api/processes");
+      expect(mockFetch).toHaveBeenCalledWith(`/api/processes${T}`);
       expect(result).toEqual({ abc: { pid: 123 } });
     });
 
     it("fetchSessionDetail calls /api/session/:id", async () => {
       mockFetch.mockReturnValue(jsonResponse({ checkpoints: [] }));
       const result = await fetchSessionDetail("test-id");
-      expect(mockFetch).toHaveBeenCalledWith("/api/session/test-id");
+      expect(mockFetch).toHaveBeenCalledWith(`/api/session/test-id${T}`);
       expect(result).toEqual({ checkpoints: [] });
     });
 
     it("fetchFiles calls /api/files", async () => {
       mockFetch.mockReturnValue(jsonResponse([]));
       await fetchFiles();
-      expect(mockFetch).toHaveBeenCalledWith("/api/files");
+      expect(mockFetch).toHaveBeenCalledWith(`/api/files${T}`);
     });
 
     it("fetchVersion calls /api/version", async () => {
@@ -79,14 +82,14 @@ describe("API client", () => {
     it("focusSession calls /api/focus/:id via POST", async () => {
       mockFetch.mockReturnValue(jsonResponse({ success: true, message: "ok" }));
       await focusSession("sid-1");
-      expect(mockFetch).toHaveBeenCalledWith("/api/focus/sid-1", { method: "POST" });
+      expect(mockFetch).toHaveBeenCalledWith(`/api/focus/sid-1${T}`, { method: "POST" });
     });
 
     it("killSession URL-encodes the session ID", async () => {
       mockFetch.mockReturnValue(jsonResponse({ success: true, message: "killed" }));
       await killSession("path/with/slashes");
       expect(mockFetch).toHaveBeenCalledWith(
-        "/api/kill/path%2Fwith%2Fslashes",
+        `/api/kill/path%2Fwith%2Fslashes${T}`,
         { method: "POST" },
       );
     });

--- a/frontend/src/test/hooks.test.ts
+++ b/frontend/src/test/hooks.test.ts
@@ -148,7 +148,7 @@ describe("useVersion", () => {
       await vi.advanceTimersByTimeAsync(0);
     });
 
-    expect(mockFetch).toHaveBeenCalledWith("/api/version");
+    expect(mockFetch).toHaveBeenCalledWith("/api/version?token=test-token");
     expect(result.current.versionInfo.update_available).toBe(true);
     expect(result.current.versionInfo.latest).toBe("2.0.0");
   });
@@ -318,8 +318,8 @@ describe("useSessions", () => {
       await vi.advanceTimersByTimeAsync(0);
     });
 
-    expect(mockFetch).toHaveBeenCalledWith("/api/sessions");
-    expect(mockFetch).toHaveBeenCalledWith("/api/processes");
+    expect(mockFetch).toHaveBeenCalledWith("/api/sessions?token=test-token");
+    expect(mockFetch).toHaveBeenCalledWith("/api/processes?token=test-token");
   });
 
   it("handles fetch failure gracefully", async () => {

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,1 +1,4 @@
 import "@testing-library/jest-dom/vitest";
+
+// Provide a known API token for tests (normally injected by the server)
+window.__DASHBOARD_TOKEN__ = "test-token";

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,1 +1,5 @@
 /// <reference types="vite/client" />
+
+interface Window {
+  __DASHBOARD_TOKEN__?: string;
+}

--- a/src/dashboard_api.py
+++ b/src/dashboard_api.py
@@ -14,6 +14,7 @@ import json
 import logging
 import os
 import re
+import secrets
 import signal
 import sqlite3
 import subprocess
@@ -26,6 +27,7 @@ from dataclasses import asdict
 from datetime import UTC, datetime
 
 from fastapi import FastAPI, Request
+from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, Response
 from fastapi.staticfiles import StaticFiles
 
@@ -85,6 +87,47 @@ app = FastAPI(
     version=__version__,
     description="Monitor all your GitHub Copilot CLI sessions in real-time.",
 )
+
+# ── Security ─────────────────────────────────────────────────────────────────
+
+# Per-instance token generated at startup; required on all /api/* requests.
+API_TOKEN: str = secrets.token_urlsafe(32)
+
+# CORS: only allow same-origin requests (no cross-origin API access)
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=[],  # no cross-origin allowed
+    allow_credentials=False,
+    allow_methods=["GET", "POST"],
+    allow_headers=["Authorization"],
+)
+
+# Paths that are exempt from token validation
+_PUBLIC_PATH_PREFIXES = (
+    "/static",
+    "/assets",
+    "/favicon",
+    "/manifest",
+    "/sw.js",
+    "/docs",
+    "/openapi.json",
+)
+
+
+@app.middleware("http")
+async def _auth_middleware(request: Request, call_next):  # type: ignore[no-untyped-def]
+    """Require a valid token on /api/* requests."""
+    path = request.url.path
+    if path.startswith("/api/"):
+        token = request.query_params.get("token")
+        if not token:
+            auth = request.headers.get("authorization", "")
+            if auth.startswith("Bearer "):
+                token = auth[7:]
+        if token != API_TOKEN:
+            return JSONResponse({"error": "Unauthorized"}, status_code=401)
+    return await call_next(request)
+
 
 # Mount /static for legacy assets (favicon, icons, etc.)
 if os.path.isdir(STATIC_DIR):
@@ -769,18 +812,31 @@ def service_worker():
 
 @app.get("/", include_in_schema=False)
 def index():
-    """Serve the React SPA or fall back to the legacy template."""
+    """Serve the React SPA or fall back to the legacy template.
+
+    Injects the API token into the page so the frontend can authenticate.
+    """
+    token_script = f'<script>window.__DASHBOARD_TOKEN__="{API_TOKEN}";</script>'
+
     # Prefer the React build if it exists
     dist_index = os.path.join(DIST_DIR, "index.html")
     if os.path.exists(dist_index):
-        return FileResponse(dist_index, media_type="text/html")
+        with open(dist_index, encoding="utf-8") as f:
+            html = f.read()
+        # Inject token before closing </head> tag
+        html = html.replace("</head>", f"{token_script}</head>", 1)
+        return HTMLResponse(html)
     # Fall back to legacy Jinja2 template
     template_path = os.path.join(TEMPLATES_DIR, "dashboard.html")
     if os.path.exists(template_path):
         with open(template_path, encoding="utf-8") as f:
             html = f.read().replace("{{ version }}", __version__)
+        html = html.replace("</head>", f"{token_script}</head>", 1)
         return HTMLResponse(html)
-    return HTMLResponse("<h1>Copilot Dashboard</h1><p>No frontend build found.</p>")
+    return HTMLResponse(
+        f"<html><head>{token_script}</head><body>"
+        "<h1>Copilot Dashboard</h1><p>No frontend build found.</p></body></html>"
+    )
 
 
 # Serve React build assets (JS, CSS, etc.) at root level so Vite's

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,34 @@
 """Shared pytest fixtures for the test suite."""
 
 import json
-import os
 import sqlite3
 
 import pytest
+from fastapi.testclient import TestClient
+
+from src.dashboard_api import API_TOKEN, app
+
+
+@pytest.fixture
+def client():
+    """TestClient that automatically includes the API auth token."""
+    real_client = TestClient(app)
+    original_get = real_client.get
+    original_post = real_client.post
+
+    def _authed_get(url, **kwargs):
+        params = kwargs.pop("params", {}) or {}
+        params["token"] = API_TOKEN
+        return original_get(url, params=params, **kwargs)
+
+    def _authed_post(url, **kwargs):
+        params = kwargs.pop("params", {}) or {}
+        params["token"] = API_TOKEN
+        return original_post(url, params=params, **kwargs)
+
+    real_client.get = _authed_get  # type: ignore[assignment]
+    real_client.post = _authed_post  # type: ignore[assignment]
+    return real_client
 
 
 @pytest.fixture

--- a/tests/test_dashboard_api_extra.py
+++ b/tests/test_dashboard_api_extra.py
@@ -5,15 +5,9 @@ import os
 from unittest.mock import MagicMock, patch
 
 import pytest
-from fastapi.testclient import TestClient
 
 from src.dashboard_api import _extract_extra_args, app
 from src.models import EventData, ProcessInfo
-
-
-@pytest.fixture
-def client():
-    return TestClient(app)
 
 
 # ---------------------------------------------------------------------------
@@ -219,3 +213,56 @@ class TestIndexFallback:
             resp = client.get("/")
         assert resp.status_code == 200
         assert "React SPA" in resp.text
+
+
+# ---------------------------------------------------------------------------
+# Auth middleware — verify token enforcement
+# ---------------------------------------------------------------------------
+
+
+class TestAuthMiddleware:
+    """Verify that the auth middleware rejects unauthenticated /api/* requests."""
+
+    def test_api_rejects_no_token(self):
+        from fastapi.testclient import TestClient
+
+        raw_client = TestClient(app)
+        resp = raw_client.get("/api/sessions")
+        assert resp.status_code == 401
+        assert resp.json() == {"error": "Unauthorized"}
+
+    def test_api_rejects_wrong_token(self):
+        from fastapi.testclient import TestClient
+
+        raw_client = TestClient(app)
+        resp = raw_client.get("/api/sessions", params={"token": "bad-token"})
+        assert resp.status_code == 401
+
+    def test_api_accepts_bearer_header(self, client):
+        from fastapi.testclient import TestClient
+
+        from src.dashboard_api import API_TOKEN
+
+        raw_client = TestClient(app)
+        resp = raw_client.get(
+            "/api/version",
+            headers={"Authorization": f"Bearer {API_TOKEN}"},
+        )
+        assert resp.status_code == 200
+
+    def test_root_accessible_without_token(self):
+        from fastapi.testclient import TestClient
+
+        raw_client = TestClient(app)
+        resp = raw_client.get("/")
+        assert resp.status_code == 200
+
+    def test_token_injected_into_html(self):
+        from fastapi.testclient import TestClient
+
+        from src.dashboard_api import API_TOKEN
+
+        raw_client = TestClient(app)
+        resp = raw_client.get("/")
+        assert API_TOKEN in resp.text
+        assert "__DASHBOARD_TOKEN__" in resp.text

--- a/tests/test_dashboard_app.py
+++ b/tests/test_dashboard_app.py
@@ -7,22 +7,14 @@ import sqlite3
 from unittest.mock import MagicMock, patch
 
 import pytest
-from fastapi.testclient import TestClient
 
 from src.dashboard_api import (
-    app,
     build_restart_command,
     get_recent_activity,
     time_ago,
 )
 from src.grouping import get_group_name
 from src.models import EventData, ProcessInfo
-
-
-# Shared test client
-@pytest.fixture
-def client():
-    return TestClient(app)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ops_commands.py
+++ b/tests/test_ops_commands.py
@@ -5,9 +5,7 @@ import sys
 from unittest.mock import MagicMock, call, patch
 
 import pytest
-from fastapi.testclient import TestClient
 
-from src.dashboard_api import app
 from src.session_dashboard import (
     TASK_NAME,
     _get_autostart_cmd_str,
@@ -165,11 +163,6 @@ class TestUpgradeRefreshMessage:
 # ---------------------------------------------------------------------------
 # API: /api/autostart endpoints
 # ---------------------------------------------------------------------------
-
-
-@pytest.fixture
-def client():
-    return TestClient(app)
 
 
 class TestApiAutostartStatus:

--- a/tests/test_version_update.py
+++ b/tests/test_version_update.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 import src.dashboard_api as dashboard_api
-from src.dashboard_api import app, _version_cache
+from src.dashboard_api import _version_cache
 
 
 @pytest.fixture(autouse=True)
@@ -20,12 +20,6 @@ def reset_version_cache():
     _version_cache.latest = None
     _version_cache.update_available = False
     _version_cache.checked_at = 0.0
-
-
-@pytest.fixture
-def client():
-    from fastapi.testclient import TestClient
-    return TestClient(app)
 
 
 def _make_pypi_response(version: str, releases: dict | None = None) -> MagicMock:


### PR DESCRIPTION
## Summary

Adds per-instance token authentication to all \/api/*\ endpoints to prevent browser-based CSRF attacks against the localhost dashboard.

## Changes

**Backend (\src/dashboard_api.py\):**
- Generate \secrets.token_urlsafe(32)\ at server startup
- HTTP middleware rejects \/api/*\ requests without a valid token (query param \?token=\ or \Authorization: Bearer\ header)
- CORS middleware blocks all cross-origin requests
- \index()\ injects token into served HTML via \window.__DASHBOARD_TOKEN__\

**Frontend (\rontend/src/api/client.ts\):**
- Reads token from \window.__DASHBOARD_TOKEN__\ and appends it to all API calls

**Tests:**
- Centralized authenticated \client\ fixture in \conftest.py\
- 5 new tests for auth enforcement (reject no token, reject wrong token, accept Bearer header, root accessible without token, token in HTML)
- All 241 tests pass

## Security Model
- Blocks CSRF: malicious websites can't read the token (CORS) so can't include it in requests
- Localhost processes can still access if they read the token from the HTML — inherent to localhost
- Token regenerated on every server restart