### PR TITLE
feat: widget bar collapse toggle and custom tooltip consistency

### DIFF
--- a/frontend/src/components/App.tsx
+++ b/frontend/src/components/App.tsx
@@ -30,7 +30,7 @@ const INITIAL_VERSION = "dev";
 function Dashboard() {
   const state = useAppState();
   const dispatch = useAppDispatch();
-  const { sessions, remoteSessions, processes, currentTab, currentView, searchFilter } = state;
+  const { sessions, remoteSessions, processes, currentTab, currentView, searchFilter, widgetsCollapsed } = state;
 
   // Start polling
   useSessions();
@@ -89,7 +89,7 @@ function Dashboard() {
       />
 
       <div className="container">
-        <StatsRow active={active} processes={processes} />
+        {!widgetsCollapsed && <StatsRow active={active} processes={processes} />}
         <TabBar activeCount={active.length} previousCount={previous.length} />
         <SearchBar />
 

--- a/frontend/src/components/FilesTab.tsx
+++ b/frontend/src/components/FilesTab.tsx
@@ -45,7 +45,10 @@ export default function FilesTab() {
 
           return (
             <tr key={f.file_path} style={{ borderBottom: "1px solid var(--border)" }}>
-              <td style={{ padding: "6px 8px", fontFamily: "monospace", color: "var(--text2)" }}>
+              <td
+                style={{ padding: "6px 8px", fontFamily: "monospace", color: "var(--text2)" }}
+                data-tip={f.file_path.length > 80 ? f.file_path : undefined}
+              >
                 {shortPath}
               </td>
               <td style={{ padding: "6px 8px", color: "var(--text)" }}>

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -46,7 +46,7 @@ export default function Header({
 
       {/* Waiting badge — only shown when sessions are waiting for input */}
       {waitingCount > 0 && (
-        <span id="waiting-badge" title="Sessions waiting for input">
+        <span id="waiting-badge" data-tip="Sessions waiting for input">
           ⏳ {waitingCount} waiting
         </span>
       )}
@@ -65,7 +65,7 @@ export default function Header({
         &nbsp;&bull;&nbsp;
         <span
           id="version-display"
-          title={
+          data-tip={
             showUpdateModal
               ? `v${versionInfo.latest} available — click to update`
               : "Up to date"
@@ -105,20 +105,20 @@ export default function Header({
           <button
             className="theme-btn"
             onClick={() => dispatch({ type: "TOGGLE_WIDGETS_COLLAPSED" })}
-            title={widgetsCollapsed ? "Show stats widgets" : "Hide stats widgets"}
+            data-tip={widgetsCollapsed ? "Show stats widgets" : "Hide stats widgets"}
           >
             {widgetsCollapsed ? "📊 Show Stats" : "📊 Hide Stats"}
           </button>
           <button
             className="theme-btn"
             onClick={toggleMode}
-            title="Toggle light/dark mode"
+            data-tip="Toggle light/dark mode"
           >
             {theme.mode === "dark" ? "🌙 Dark" : "☀️ Light"}
           </button>
           <select
             className="palette-select"
-            title="Color palette"
+            data-tip="Color palette"
             value={theme.palette}
             onChange={(e) => setPalette(e.target.value as Palette)}
           >
@@ -147,7 +147,7 @@ export default function Header({
             color: "var(--text2)",
             fontFamily: "monospace",
           }}
-          title="Dashboard server process ID"
+          data-tip="Dashboard server process ID"
         >
           server PID {serverPid}
         </div>

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -5,7 +5,7 @@
 
 import { useTheme, useVersion } from "../hooks";
 import type { Palette } from "../hooks";
-import { useAppState } from "../state";
+import { useAppState, useAppDispatch } from "../state";
 import { PALETTE_OPTIONS } from "../constants";
 
 interface HeaderProps {
@@ -24,7 +24,8 @@ export default function Header({
 }: HeaderProps) {
   const { theme, toggleMode, setPalette } = useTheme();
   const { versionInfo, updating, doUpdate } = useVersion(initialVersion);
-  const { serverPid } = useAppState();
+  const { serverPid, widgetsCollapsed } = useAppState();
+  const dispatch = useAppDispatch();
 
   const showUpdateModal = versionInfo.update_available && !updating;
 
@@ -101,6 +102,13 @@ export default function Header({
 
       <div className="header-right">
         <div className="theme-controls">
+          <button
+            className="theme-btn"
+            onClick={() => dispatch({ type: "TOGGLE_WIDGETS_COLLAPSED" })}
+            title={widgetsCollapsed ? "Show stats widgets" : "Hide stats widgets"}
+          >
+            {widgetsCollapsed ? "📊 Show Stats" : "📊 Hide Stats"}
+          </button>
           <button
             className="theme-btn"
             onClick={toggleMode}

--- a/frontend/src/components/TabBar.tsx
+++ b/frontend/src/components/TabBar.tsx
@@ -56,7 +56,7 @@ export default function TabBar({ activeCount, previousCount }: TabBarProps) {
             className={`tab ${currentTab === t.key ? "active" : ""}`}
             data-tab={t.key}
             onClick={() => switchTab(t.key)}
-            title={t.title}
+            data-tip={t.title}
           >
             {t.icon} {t.label}
             {t.count !== undefined && (
@@ -88,14 +88,14 @@ export default function TabBar({ activeCount, previousCount }: TabBarProps) {
         <button
           className={`view-btn ${currentView === "tile" ? "active" : ""}`}
           onClick={() => setView("tile")}
-          title="Tile view"
+          data-tip="Tile view"
         >
           ▦
         </button>
         <button
           className={`view-btn ${currentView === "list" ? "active" : ""}`}
           onClick={() => setView("list")}
-          title="List view"
+          data-tip="List view"
         >
           ☰
         </button>

--- a/frontend/src/components/Timeline.tsx
+++ b/frontend/src/components/Timeline.tsx
@@ -141,7 +141,7 @@ export default function Timeline({ sessions, processes, now, onOpenDetail }: Tim
               textAlign: "right",
               paddingRight: 8,
             }}
-            title={s.summary || ""}
+            data-tip={s.summary || ""}
           >
             {label}
           </div>
@@ -168,7 +168,7 @@ export default function Timeline({ sessions, processes, now, onOpenDetail }: Tim
                 minWidth: 4,
                 opacity: 0.85,
               }}
-              title={`${s.summary || ""} — ${s.created_ago}`}
+              data-tip={`${s.summary || ""} — ${s.created_ago}`}
             />
           </div>
         </div>

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -48,6 +48,7 @@ export const STORAGE_KEY_MODE = "dash-mode";
 export const STORAGE_KEY_PALETTE = "dash-palette";
 export const STORAGE_KEY_VIEW = "dash-view";
 export const STORAGE_KEY_STARRED = "dash-starred";
+export const STORAGE_KEY_WIDGETS_COLLAPSED = "dash-widgets-collapsed";
 
 // ── Theme options ──────────────────────────────────────────────────────────
 

--- a/frontend/src/state/AppContext.tsx
+++ b/frontend/src/state/AppContext.tsx
@@ -23,6 +23,7 @@ import {
   DISCONNECT_THRESHOLD,
   STORAGE_KEY_STARRED,
   STORAGE_KEY_VIEW,
+  STORAGE_KEY_WIDGETS_COLLAPSED,
 } from "../constants";
 import type { Session, ProcessMap } from "../types";
 
@@ -53,6 +54,7 @@ export interface AppState {
   expandedSessionIds: Set<string>;
   collapsedGroups: Set<string>;
   starredSessions: Set<string>;
+  widgetsCollapsed: boolean;
   notificationsEnabled: boolean;
   consecutiveFailures: number;
   lastFetchedAt: number | null;
@@ -72,6 +74,7 @@ export function initialState(): AppState {
     expandedSessionIds: new Set(),
     collapsedGroups: new Set(),
     starredSessions: safeParseStarred(),
+    widgetsCollapsed: localStorage.getItem(STORAGE_KEY_WIDGETS_COLLAPSED) === "true",
     notificationsEnabled:
       typeof Notification !== "undefined" &&
       Notification.permission === "granted",
@@ -93,6 +96,7 @@ export type Action =
   | { type: "TOGGLE_EXPAND"; sessionId: string }
   | { type: "TOGGLE_GROUP"; groupId: string }
   | { type: "TOGGLE_STAR"; sessionId: string }
+  | { type: "TOGGLE_WIDGETS_COLLAPSED" }
   | { type: "SET_NOTIFICATIONS"; enabled: boolean }
   | { type: "RECORD_FETCH_SUCCESS" }
   | { type: "RECORD_FETCH_FAILURE" }
@@ -145,6 +149,9 @@ export function appReducer(state: AppState, action: Action): AppState {
       return { ...state, starredSessions: next };
     }
 
+    case "TOGGLE_WIDGETS_COLLAPSED":
+      return { ...state, widgetsCollapsed: !state.widgetsCollapsed };
+
     case "SET_NOTIFICATIONS":
       return { ...state, notificationsEnabled: action.enabled };
 
@@ -187,6 +194,10 @@ export function AppProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     localStorage.setItem(STORAGE_KEY_STARRED, JSON.stringify([...state.starredSessions]));
   }, [state.starredSessions]);
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY_WIDGETS_COLLAPSED, String(state.widgetsCollapsed));
+  }, [state.widgetsCollapsed]);
 
   return (
     <AppStateContext.Provider value={state}>

--- a/frontend/src/test/components.test.tsx
+++ b/frontend/src/test/components.test.tsx
@@ -346,8 +346,8 @@ describe("TabBar", () => {
 
   it("renders tile and list view buttons", () => {
     renderWithProvider(<TabBar activeCount={0} previousCount={0} />);
-    expect(screen.getByTitle("Tile view")).toBeInTheDocument();
-    expect(screen.getByTitle("List view")).toBeInTheDocument();
+    expect(document.querySelector('[data-tip="Tile view"]')).toBeInTheDocument();
+    expect(document.querySelector('[data-tip="List view"]')).toBeInTheDocument();
   });
 
   it("renders notification button", () => {
@@ -706,14 +706,14 @@ describe("TabBar — interactions", () => {
 
   it("clicking tile view button activates tile view", () => {
     renderWithProvider(<TabBar activeCount={0} previousCount={0} />);
-    const tileBtn = screen.getByTitle("Tile view");
+    const tileBtn = document.querySelector('[data-tip="Tile view"]') as HTMLElement;
     fireEvent.click(tileBtn);
     expect(tileBtn.classList.contains("active")).toBe(true);
   });
 
   it("clicking list view button activates list view", () => {
     renderWithProvider(<TabBar activeCount={0} previousCount={0} />);
-    const listBtn = screen.getByTitle("List view");
+    const listBtn = document.querySelector('[data-tip="List view"]') as HTMLElement;
     fireEvent.click(listBtn);
     expect(listBtn.classList.contains("active")).toBe(true);
   });


### PR DESCRIPTION
## Summary

Adds a toggle to expand/collapse the stats widget bar at the top of the dashboard, and converts all remaining native browser tooltips to use the custom styled tooltip component.

### Changes

**Widget bar collapse toggle**
- New \📊 Show/Hide Stats\ button in the header next to theme controls
- State persisted to localStorage (\dash-widgets-collapsed\) — survives page reloads, same pattern as themes
- Added \STORAGE_KEY_WIDGETS_COLLAPSED\ constant, \widgetsCollapsed\ state + \TOGGLE_WIDGETS_COLLAPSED\ action in AppContext

**Custom tooltip consistency**
- Converted all native \	itle=\ HTML attributes to \data-tip=\ across Header, TabBar, Timeline, and FilesTab
- All tooltips now use the styled custom tooltip component (follows cursor, themed, 400ms delay)

**Truncated text tooltips**
- Timeline: hovering over truncated session labels shows the full summary
- Files tab: hovering over truncated file paths (>80 chars) shows the full path

### Testing
- All 179 frontend tests pass (3 updated to use \data-tip\ selectors)
- All 241 Python backend tests pass
- TypeScript type checks pass
- Manual verification on dev server