### PR TITLE
feat: hamburger menu with settings toggles and About modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,41 +68,23 @@ Open **http://localhost:5111** in your browser.
 
 - **Claude Code support** — automatically discovers Claude Code sessions from `~/.claude/projects/`. Active Claude sessions appear alongside Copilot sessions with a `✦ Claude` badge.
 - **Cross-machine sync** — see active sessions from all your machines in one dashboard, powered by OneDrive or any cloud-synced folder. See [Cross-Machine Sync](#cross-machine-sync) for details.
-- **Upgrade command** — `copilot-dashboard upgrade` stops the server, upgrades via pip, and restarts automatically. Just refresh your browser.
-- **Autostart** — `copilot-dashboard autostart` registers the dashboard to start at Windows login via Task Scheduler.
-- **Background tasks** — shows count of running subagents per session.
+- **Settings menu** — ☰ hamburger menu in the header with toggles for autostart-on-login and remote sync.
+- **Upgrade command** — `copilot-dashboard upgrade` stops the server, upgrades via pip, and restarts automatically.
 
 ### Session States
 - **Working / Thinking** (green) — session is actively running tools or reasoning
 - **Waiting** (yellow) — session needs your input (`ask_user` or `ask_permission` pending)
 - **Idle** (blue) — session is done and ready for your next task
 
-### Desktop Notifications
-Click the 🔕 button in the header to enable browser notifications. You'll get an alert whenever a session transitions from working to waiting or idle, so you can stay on top of sessions that need attention without watching the dashboard.
-
-### Views
-- **Tile view** (default) — compact card grid to see all sessions at a glance
-- **List view** — detailed expandable rows with full session info
-- Toggle between views with the buttons next to the Active/Previous tabs
-
-### Session Monitoring
-- **Active vs Previous** — sessions with a running `copilot.exe` or `claude.exe` process appear in the Active tab
-- **Claude Code support** — automatically discovers Claude Code sessions from `~/.claude/projects/`, including active sessions not yet indexed. Claude sessions display a `✦ Claude` badge.
-- **Waiting context** — when a session is waiting, shows *what* it's asking (e.g. the `ask_user` question and choices)
+### Key Features
+- **Desktop notifications** — get alerts when sessions transition between states
+- **Focus window** — bring an active session's terminal to the foreground with one click
+- **Restart commands** — copy-pasteable `copilot --resume <id>` commands for every session
+- **Waiting context** — shows *what* a waiting session is asking (e.g. the `ask_user` question and choices)
 - **Background tasks** — shows count of running subagents per session
-- **YOLO mode indicator** — shows 🔥 YOLO badge for sessions running with `--yolo`
-- **MCP servers** — displays connected MCP servers (e.g. bluebird, icm, github) for both active and past sessions
-- **Project grouping** — sessions are auto-categorized by repo, working directory, or content analysis
-
-### Actions
-- **Focus window** — click 📺 on an active session to bring its terminal window to the foreground
-- **Restart commands** — each session has a copy-pasteable `copilot --resume <id>` command (includes `--yolo` only if the session was running with it)
 - **Session details** — click any session to see checkpoints, recent tool output, references, and conversation history
-
-### Appearance
-- **Light/Dark mode** toggle
-- **9 color palettes** — Default, Pink, Ocean, Forest, Sunset, Mono, Neon, Slate, and Rose Gold
-- **Auto-refresh** — active sessions poll every 5s, full session list every 30s; expanded sections and collapsed groups persist across refreshes
+- **Tile & List views** — compact card grid or detailed expandable rows
+- **9 color palettes** and light/dark mode
 
 ### Cross-Machine Sync
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -13,6 +13,7 @@ import type {
   VersionInfo,
   ServerInfo,
   AutostartStatus,
+  DashboardSettings,
 } from "../types";
 
 /** Generic GET helper — throws on non-2xx responses. */
@@ -25,6 +26,17 @@ async function get<T>(url: string): Promise<T> {
 /** Generic POST helper — throws on non-2xx responses. */
 async function post<T>(url: string): Promise<T> {
   const resp = await fetch(url, { method: "POST" });
+  if (!resp.ok) throw new Error(`${resp.status} ${resp.statusText}`);
+  return resp.json() as Promise<T>;
+}
+
+/** Generic PUT+JSON helper — throws on non-2xx responses. */
+async function put<T>(url: string, body: unknown): Promise<T> {
+  const resp = await fetch(url, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
   if (!resp.ok) throw new Error(`${resp.status} ${resp.statusText}`);
   return resp.json() as Promise<T>;
 }
@@ -108,4 +120,23 @@ export function fetchAutostartStatus(): Promise<AutostartStatus> {
 /** Enable autostart via the backend (Windows Task Scheduler). */
 export function enableAutostart(): Promise<{ success: boolean; message: string }> {
   return post("/api/autostart/enable");
+}
+
+/** Disable autostart via the backend. */
+export function disableAutostart(): Promise<{ success: boolean; message: string }> {
+  return post("/api/autostart/disable");
+}
+
+// ── Settings ─────────────────────────────────────────────────────────────────
+
+/** Fetch current dashboard settings (sync toggle, etc.). */
+export function fetchSettings(): Promise<DashboardSettings> {
+  return get<DashboardSettings>("/api/settings");
+}
+
+/** Update dashboard settings. */
+export function updateSettings(
+  patch: Partial<DashboardSettings>,
+): Promise<DashboardSettings> {
+  return put<DashboardSettings>("/api/settings", patch);
 }

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -6,9 +6,12 @@ export {
   fetchRemoteSessions,
   fetchVersion,
   fetchServerInfo,
+  fetchSettings,
+  updateSettings,
   focusSession,
   killSession,
   triggerUpdate,
   fetchAutostartStatus,
   enableAutostart,
+  disableAutostart,
 } from "./client";

--- a/frontend/src/components/AutostartPopover.tsx
+++ b/frontend/src/components/AutostartPopover.tsx
@@ -6,7 +6,7 @@
 import { useAutostart } from "../hooks";
 
 export default function AutostartPopover() {
-  const { showPrompt, enabling, enable, dismiss } = useAutostart();
+  const { showPrompt, toggling, enable, dismiss } = useAutostart();
 
   if (!showPrompt) return null;
 
@@ -52,19 +52,19 @@ export default function AutostartPopover() {
         </button>
         <button
           onClick={enable}
-          disabled={enabling}
+          disabled={toggling}
           style={{
             background: "var(--accent, #58a6ff)",
             border: "none",
             color: "#fff",
             borderRadius: 6,
             padding: "5px 14px",
-            cursor: enabling ? "wait" : "pointer",
+            cursor: toggling ? "wait" : "pointer",
             fontSize: 13,
             fontWeight: 600,
           }}
         >
-          {enabling ? "Enabling…" : "Enable"}
+          {toggling ? "Enabling…" : "Enable"}
         </button>
       </div>
     </div>

--- a/frontend/src/components/HamburgerMenu.tsx
+++ b/frontend/src/components/HamburgerMenu.tsx
@@ -92,13 +92,6 @@ export default function HamburgerMenu() {
             <button
               className="hamburger-item"
               role="menuitem"
-              style={{
-                background: "none",
-                border: "none",
-                font: "inherit",
-                width: "100%",
-                textAlign: "left",
-              }}
               onClick={() => {
                 setOpen(false);
                 setShowAbout(true);
@@ -121,8 +114,8 @@ export default function HamburgerMenu() {
           <div className="modal">
             <h2>🤖 Copilot Dashboard</h2>
             <p>
-              A local dashboard that monitors all your GitHub Copilot CLI
-              sessions in real-time.
+              A local dashboard that monitors all your GitHub Copilot CLI and
+              Claude Code sessions in real-time.
             </p>
             <p>
               <a
@@ -139,52 +132,34 @@ export default function HamburgerMenu() {
             </p>
             <ul>
               <li>
-                <strong>Active vs Previous</strong> — sessions with a running
-                process show in the Active tab with a live indicator; completed
-                sessions are in Previous.
+                <strong>Claude Code support</strong> — automatically discovers
+                Claude Code sessions alongside Copilot sessions.
               </li>
               <li>
                 <strong>Session states</strong> —{" "}
-                <span style={{ color: "var(--green)" }}>● Working/Thinking</span>{" "}
-                (actively running),{" "}
+                <span style={{ color: "var(--green)" }}>● Working/Thinking</span>,{" "}
                 <span style={{ color: "var(--yellow)" }}>● Waiting</span> (needs
-                your input),{" "}
-                <span style={{ color: "var(--accent)" }}>● Idle</span> (done,
-                ready for next task).
+                input),{" "}
+                <span style={{ color: "var(--accent)" }}>● Idle</span> (ready
+                for next task).
               </li>
               <li>
-                <strong>Desktop notifications</strong> — click the 🔕 button to
-                enable browser notifications when sessions change state.
+                <strong>Cross-machine sync</strong> — see active sessions from
+                all your machines via OneDrive or any cloud-synced folder.
               </li>
               <li>
-                <strong>Background tasks</strong> — sessions running subagents
-                show a badge with the count of active background tasks.
+                <strong>Desktop notifications</strong> — get alerts when sessions
+                change state so you don't have to watch the dashboard.
               </li>
               <li>
-                <strong>Grouped by project</strong> — sessions are automatically
-                categorized by repository or working directory.
+                <strong>Focus window</strong> — bring an active session's
+                terminal to the foreground with one click.
               </li>
               <li>
-                <strong>Restart commands</strong> — each session has a
-                copy-pasteable <code>copilot</code> command to resume it.
-              </li>
-              <li>
-                <strong>Focus window</strong> — click the 📺 button on an active
-                session to bring its terminal to the foreground.
-              </li>
-              <li>
-                <strong>Tile &amp; List views</strong> — tile view for
-                at-a-glance status, list view for full details.
-              </li>
-              <li>
-                <strong>Themes</strong> — toggle light/dark mode and switch color
-                palettes using the controls in the header.
+                <strong>Restart commands</strong> — copy-pasteable resume
+                commands for every session.
               </li>
             </ul>
-            <p>
-              <strong>Refresh rates:</strong> Active sessions refresh every 5
-              seconds. Previous sessions refresh every 30 seconds.
-            </p>
             <button
               className="close-btn"
               onClick={() => setShowAbout(false)}

--- a/frontend/src/components/HamburgerMenu.tsx
+++ b/frontend/src/components/HamburgerMenu.tsx
@@ -6,7 +6,7 @@
  *   - "Start on login" toggle (hidden when platform doesn't support it)
  *   - "Remote sync" toggle (enables/disables OneDrive sync)
  *   - Divider
- *   - "About" link → GitHub repo (replaces old "What is this?")
+ *   - "About" opens a help modal (restored from the old "What is this?" popup)
  */
 
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -14,6 +14,7 @@ import { useAutostart, useSettings } from "../hooks";
 
 export default function HamburgerMenu() {
   const [open, setOpen] = useState(false);
+  const [showAbout, setShowAbout] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
 
   const autostart = useAutostart();
@@ -44,61 +45,148 @@ export default function HamburgerMenu() {
   }, [open]);
 
   return (
-    <div className="hamburger-wrapper" ref={menuRef}>
-      <button
-        className="hamburger-btn"
-        onClick={toggle}
-        title="Settings"
-        aria-label="Open settings menu"
-        aria-expanded={open}
-      >
-        ☰
-      </button>
+    <>
+      <div className="hamburger-wrapper" ref={menuRef}>
+        <button
+          className="hamburger-btn"
+          onClick={toggle}
+          title="Settings"
+          aria-label="Open settings menu"
+          aria-expanded={open}
+        >
+          ☰
+        </button>
 
-      {open && (
-        <div className="hamburger-dropdown" role="menu">
-          {/* Autostart toggle — only shown when platform supports it */}
-          {autostart.supported && (
-            <label className="hamburger-item hamburger-toggle" role="menuitem">
-              <span>Start on login</span>
-              <input
-                type="checkbox"
-                checked={autostart.enabled}
-                disabled={autostart.toggling}
-                onChange={(e) => autostart.toggle(e.target.checked)}
-              />
-              <span className="toggle-slider" />
-            </label>
-          )}
+        {open && (
+          <div className="hamburger-dropdown" role="menu">
+            {/* Autostart toggle — only shown when platform supports it */}
+            {autostart.supported && (
+              <label className="hamburger-item hamburger-toggle" role="menuitem">
+                <span>Start on login</span>
+                <input
+                  type="checkbox"
+                  checked={autostart.enabled}
+                  disabled={autostart.toggling}
+                  onChange={(e) => autostart.toggle(e.target.checked)}
+                />
+                <span className="toggle-slider" />
+              </label>
+            )}
 
-          {/* Remote sync toggle */}
-          {!settingsLoading && (
-            <label className="hamburger-item hamburger-toggle" role="menuitem">
-              <span>Remote sync</span>
-              <input
-                type="checkbox"
-                checked={settings.sync_enabled}
-                onChange={(e) => setSyncEnabled(e.target.checked)}
-              />
-              <span className="toggle-slider" />
-            </label>
-          )}
+            {/* Remote sync toggle */}
+            {!settingsLoading && (
+              <label className="hamburger-item hamburger-toggle" role="menuitem">
+                <span>Remote sync</span>
+                <input
+                  type="checkbox"
+                  checked={settings.sync_enabled}
+                  onChange={(e) => setSyncEnabled(e.target.checked)}
+                />
+                <span className="toggle-slider" />
+              </label>
+            )}
 
-          <div className="hamburger-divider" />
+            <div className="hamburger-divider" />
 
-          {/* About link */}
-          <a
-            className="hamburger-item"
-            href="https://github.com/JeffSteinbok/ghcpCliDashboard"
-            target="_blank"
-            rel="noreferrer"
-            role="menuitem"
-            onClick={() => setOpen(false)}
-          >
-            About
-          </a>
+            {/* About — opens help modal */}
+            <button
+              className="hamburger-item"
+              role="menuitem"
+              onClick={() => {
+                setOpen(false);
+                setShowAbout(true);
+              }}
+            >
+              About
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* About modal — restored from the legacy "What is this?" popup */}
+      {showAbout && (
+        <div
+          className="modal-overlay open"
+          onClick={(e) => {
+            if (e.target === e.currentTarget) setShowAbout(false);
+          }}
+        >
+          <div className="modal">
+            <h2>🤖 Copilot Dashboard</h2>
+            <p>
+              A local dashboard that monitors all your GitHub Copilot CLI
+              sessions in real-time.
+            </p>
+            <p>
+              <a
+                href="https://github.com/JeffSteinbok/ghcpCliDashboard"
+                target="_blank"
+                rel="noreferrer"
+                style={{ color: "var(--accent)", textDecoration: "underline" }}
+              >
+                📖 View full documentation on GitHub
+              </a>
+            </p>
+            <p>
+              <strong>Features:</strong>
+            </p>
+            <ul>
+              <li>
+                <strong>Active vs Previous</strong> — sessions with a running
+                process show in the Active tab with a live indicator; completed
+                sessions are in Previous.
+              </li>
+              <li>
+                <strong>Session states</strong> —{" "}
+                <span style={{ color: "var(--green)" }}>● Working/Thinking</span>{" "}
+                (actively running),{" "}
+                <span style={{ color: "var(--yellow)" }}>● Waiting</span> (needs
+                your input),{" "}
+                <span style={{ color: "var(--accent)" }}>● Idle</span> (done,
+                ready for next task).
+              </li>
+              <li>
+                <strong>Desktop notifications</strong> — click the 🔕 button to
+                enable browser notifications when sessions change state.
+              </li>
+              <li>
+                <strong>Background tasks</strong> — sessions running subagents
+                show a badge with the count of active background tasks.
+              </li>
+              <li>
+                <strong>Grouped by project</strong> — sessions are automatically
+                categorized by repository or working directory.
+              </li>
+              <li>
+                <strong>Restart commands</strong> — each session has a
+                copy-pasteable <code>copilot</code> command to resume it.
+              </li>
+              <li>
+                <strong>Focus window</strong> — click the 📺 button on an active
+                session to bring its terminal to the foreground.
+              </li>
+              <li>
+                <strong>Tile &amp; List views</strong> — tile view for
+                at-a-glance status, list view for full details.
+              </li>
+              <li>
+                <strong>Themes</strong> — toggle light/dark mode and switch color
+                palettes using the controls in the header.
+              </li>
+            </ul>
+            <p>
+              <strong>Refresh rates:</strong> Active sessions refresh every 5
+              seconds. Previous sessions refresh every 30 seconds.
+            </p>
+            <button
+              className="close-btn"
+              onClick={() => setShowAbout(false)}
+            >
+              Got it
+            </button>
+          </div>
         </div>
       )}
-    </div>
+    </>
   );
 }

--- a/frontend/src/components/HamburgerMenu.tsx
+++ b/frontend/src/components/HamburgerMenu.tsx
@@ -92,6 +92,13 @@ export default function HamburgerMenu() {
             <button
               className="hamburger-item"
               role="menuitem"
+              style={{
+                background: "none",
+                border: "none",
+                font: "inherit",
+                width: "100%",
+                textAlign: "left",
+              }}
               onClick={() => {
                 setOpen(false);
                 setShowAbout(true);

--- a/frontend/src/components/HamburgerMenu.tsx
+++ b/frontend/src/components/HamburgerMenu.tsx
@@ -1,0 +1,104 @@
+/**
+ * Hamburger menu (☰) — dropdown in the header-right area, next to
+ * the timestamp.
+ *
+ * Contains:
+ *   - "Start on login" toggle (hidden when platform doesn't support it)
+ *   - "Remote sync" toggle (enables/disables OneDrive sync)
+ *   - Divider
+ *   - "About" link → GitHub repo (replaces old "What is this?")
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useAutostart, useSettings } from "../hooks";
+
+export default function HamburgerMenu() {
+  const [open, setOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  const autostart = useAutostart();
+  const { settings, loading: settingsLoading, setSyncEnabled } = useSettings();
+
+  const toggle = useCallback(() => setOpen((prev) => !prev), []);
+
+  // Close on outside click
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [open]);
+
+  // Close on Escape
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [open]);
+
+  return (
+    <div className="hamburger-wrapper" ref={menuRef}>
+      <button
+        className="hamburger-btn"
+        onClick={toggle}
+        title="Settings"
+        aria-label="Open settings menu"
+        aria-expanded={open}
+      >
+        ☰
+      </button>
+
+      {open && (
+        <div className="hamburger-dropdown" role="menu">
+          {/* Autostart toggle — only shown when platform supports it */}
+          {autostart.supported && (
+            <label className="hamburger-item hamburger-toggle" role="menuitem">
+              <span>Start on login</span>
+              <input
+                type="checkbox"
+                checked={autostart.enabled}
+                disabled={autostart.toggling}
+                onChange={(e) => autostart.toggle(e.target.checked)}
+              />
+              <span className="toggle-slider" />
+            </label>
+          )}
+
+          {/* Remote sync toggle */}
+          {!settingsLoading && (
+            <label className="hamburger-item hamburger-toggle" role="menuitem">
+              <span>Remote sync</span>
+              <input
+                type="checkbox"
+                checked={settings.sync_enabled}
+                onChange={(e) => setSyncEnabled(e.target.checked)}
+              />
+              <span className="toggle-slider" />
+            </label>
+          )}
+
+          <div className="hamburger-divider" />
+
+          {/* About link */}
+          <a
+            className="hamburger-item"
+            href="https://github.com/JeffSteinbok/ghcpCliDashboard"
+            target="_blank"
+            rel="noreferrer"
+            role="menuitem"
+            onClick={() => setOpen(false)}
+          >
+            About
+          </a>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -7,6 +7,7 @@ import { useTheme, useVersion } from "../hooks";
 import type { Palette } from "../hooks";
 import { useAppState } from "../state";
 import { PALETTE_OPTIONS } from "../constants";
+import HamburgerMenu from "./HamburgerMenu";
 
 interface HeaderProps {
   /** Version string from the Python package, e.g. "1.2.3". */
@@ -89,14 +90,6 @@ export default function Header({
           {updating && " ⏳ Updating…"}
           {showUpdateModal && " ⬆"}
         </span>
-        &nbsp;&bull;&nbsp;
-        <a
-          href="https://github.com/JeffSteinbok/ghcpCliDashboard"
-          target="_blank"
-          rel="noreferrer"
-        >
-          What is this?
-        </a>
       </div>
 
       <div className="header-right">
@@ -125,6 +118,7 @@ export default function Header({
           <span className="refresh-dot" />
           <span id="last-updated">{lastUpdated}</span>
         </div>
+        <HamburgerMenu />
       </div>
 
       {/* Server PID — small fixed footer element */}

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -4,4 +4,5 @@ export { useNotifications } from "./useNotifications";
 export { useDisconnect } from "./useDisconnect";
 export { useVersion } from "./useVersion";
 export { useAutostart } from "./useAutostart";
+export { useSettings } from "./useSettings";
 export type { Mode, Palette, ThemeState } from "./useTheme";

--- a/frontend/src/hooks/useAutostart.ts
+++ b/frontend/src/hooks/useAutostart.ts
@@ -1,60 +1,72 @@
 /**
- * Hook that checks autostart status once on mount and provides
- * state for the autostart prompt popover.
+ * Hook that checks autostart status and provides toggle functionality
+ * for the hamburger menu, plus the one-time prompt popover.
  */
 
 import { useEffect, useState, useCallback } from "react";
-import { fetchAutostartStatus, enableAutostart } from "../api";
+import { fetchAutostartStatus, enableAutostart, disableAutostart } from "../api";
 
 const DISMISSED_KEY = "copilot-dashboard-autostart-dismissed";
 
 interface AutostartState {
-  /** Whether to show the popover prompt */
+  /** Whether autostart is supported on this platform */
+  supported: boolean;
+  /** Whether autostart is currently enabled */
+  enabled: boolean;
+  /** Whether to show the one-time popover prompt */
   showPrompt: boolean;
-  /** User clicked "Enable" — request in flight */
-  enabling: boolean;
-  /** Call to enable autostart */
+  /** Request in flight */
+  toggling: boolean;
+  /** Toggle autostart on or off */
+  toggle: (enabled: boolean) => void;
+  /** Call to enable autostart (from popover) */
   enable: () => void;
   /** Call to dismiss the popover permanently */
   dismiss: () => void;
 }
 
 export function useAutostart(): AutostartState {
+  const [supported, setSupported] = useState(false);
+  const [enabled, setEnabled] = useState(false);
   const [showPrompt, setShowPrompt] = useState(false);
-  const [enabling, setEnabling] = useState(false);
+  const [toggling, setToggling] = useState(false);
 
   useEffect(() => {
-    // Don't prompt if user previously dismissed
-    if (localStorage.getItem(DISMISSED_KEY)) return;
-
     fetchAutostartStatus()
       .then((status) => {
-        if (status.supported && !status.enabled) {
+        setSupported(status.supported);
+        setEnabled(status.enabled);
+        // Show prompt if supported, not enabled, and not previously dismissed
+        if (status.supported && !status.enabled && !localStorage.getItem(DISMISSED_KEY)) {
           setShowPrompt(true);
         }
       })
       .catch(() => {});
   }, []);
 
-  const enable = useCallback(() => {
-    setEnabling(true);
-    enableAutostart()
+  const toggle = useCallback((newEnabled: boolean) => {
+    setToggling(true);
+    const action = newEnabled ? enableAutostart() : disableAutostart();
+    action
       .then((res) => {
         if (res.success) {
-          localStorage.setItem(DISMISSED_KEY, "1");
-          setShowPrompt(false);
-        } else {
-          alert(`Could not enable autostart: ${res.message}`);
+          setEnabled(newEnabled);
+          if (newEnabled) {
+            localStorage.setItem(DISMISSED_KEY, "1");
+            setShowPrompt(false);
+          }
         }
       })
-      .catch(() => alert("Failed to enable autostart."))
-      .finally(() => setEnabling(false));
+      .catch(() => {})
+      .finally(() => setToggling(false));
   }, []);
+
+  const enable = useCallback(() => toggle(true), [toggle]);
 
   const dismiss = useCallback(() => {
     localStorage.setItem(DISMISSED_KEY, "1");
     setShowPrompt(false);
   }, []);
 
-  return { showPrompt, enabling, enable, dismiss };
+  return { supported, enabled, showPrompt, toggling, toggle, enable, dismiss };
 }

--- a/frontend/src/hooks/useSettings.ts
+++ b/frontend/src/hooks/useSettings.ts
@@ -1,0 +1,38 @@
+/**
+ * Hook to fetch and update dashboard settings (sync toggle) from the backend.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import { fetchSettings, updateSettings } from "../api";
+import type { DashboardSettings } from "../types";
+
+const DEFAULT_SETTINGS: DashboardSettings = {
+  sync_enabled: true,
+};
+
+export interface UseSettingsResult {
+  settings: DashboardSettings;
+  loading: boolean;
+  setSyncEnabled: (enabled: boolean) => void;
+}
+
+export function useSettings(): UseSettingsResult {
+  const [settings, setSettings] = useState<DashboardSettings>(DEFAULT_SETTINGS);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetchSettings()
+      .then(setSettings)
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, []);
+
+  const setSyncEnabled = useCallback((enabled: boolean) => {
+    setSettings((prev) => ({ ...prev, sync_enabled: enabled }));
+    updateSettings({ sync_enabled: enabled })
+      .then(setSettings)
+      .catch(() => {});
+  }, []);
+
+  return { settings, loading, setSyncEnabled };
+}

--- a/frontend/src/themes.css
+++ b/frontend/src/themes.css
@@ -236,6 +236,9 @@ a:hover { text-decoration: underline; }
   text-decoration: none; cursor: pointer; transition: background 0.12s;
 }
 .hamburger-item:hover { background: var(--copy-hover); text-decoration: none; }
+button.hamburger-item {
+  background: none; border: none; font: inherit; width: 100%; text-align: left;
+}
 .hamburger-divider {
   height: 1px; background: var(--border); margin: 4px 0;
 }

--- a/frontend/src/themes.css
+++ b/frontend/src/themes.css
@@ -216,6 +216,50 @@ a:hover { text-decoration: underline; }
 }
 @keyframes pulse { 0%,100%{opacity:1;} 50%{opacity:0.3;} }
 
+/* ===== HAMBURGER MENU ===== */
+.hamburger-wrapper { position: relative; }
+.hamburger-btn {
+  background: var(--surface2); border: 1px solid var(--border); color: var(--text);
+  border-radius: 6px; padding: 4px 10px; font-size: 18px; cursor: pointer;
+  line-height: 1; transition: background 0.15s;
+}
+.hamburger-btn:hover { background: var(--copy-hover); }
+.hamburger-dropdown {
+  position: absolute; top: calc(100% + 6px); right: 0;
+  background: var(--surface); border: 1px solid var(--border);
+  border-radius: 8px; min-width: 200px; padding: 6px 0;
+  box-shadow: 0 8px 24px rgba(0,0,0,0.3); z-index: 200;
+}
+.hamburger-item {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 8px 16px; font-size: 14px; color: var(--text);
+  text-decoration: none; cursor: pointer; transition: background 0.12s;
+}
+.hamburger-item:hover { background: var(--copy-hover); text-decoration: none; }
+.hamburger-divider {
+  height: 1px; background: var(--border); margin: 4px 0;
+}
+
+/* Toggle switch */
+.hamburger-toggle { cursor: pointer; gap: 12px; }
+.hamburger-toggle input { display: none; }
+.toggle-slider {
+  position: relative; width: 36px; height: 20px; flex-shrink: 0;
+  background: var(--border); border-radius: 10px;
+  transition: background 0.2s;
+}
+.toggle-slider::after {
+  content: ""; position: absolute; top: 2px; left: 2px;
+  width: 16px; height: 16px; border-radius: 50%;
+  background: var(--text); transition: transform 0.2s;
+}
+.hamburger-toggle input:checked + .toggle-slider {
+  background: var(--accent);
+}
+.hamburger-toggle input:checked + .toggle-slider::after {
+  transform: translateX(16px);
+}
+
 /* ===== CONTAINER ===== */
 .container { max-width: 1280px; margin: 0 auto; padding: 20px 24px; }
 

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -121,3 +121,8 @@ export interface AutostartStatus {
   supported: boolean;
   enabled: boolean;
 }
+
+/** GET/PUT /api/settings response. */
+export interface DashboardSettings {
+  sync_enabled: boolean;
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,3 +1,3 @@
 export type { Session, SessionDetail, ProcessInfo, ProcessMap, BackgroundTask } from "./api";
 export type { Checkpoint, Ref, Turn, ToolCount } from "./api";
-export type { FileFrequency, VersionInfo, ServerInfo, AutostartStatus } from "./api";
+export type { FileFrequency, VersionInfo, ServerInfo, AutostartStatus, DashboardSettings } from "./api";

--- a/src/dashboard_api.py
+++ b/src/dashboard_api.py
@@ -39,6 +39,7 @@ from .claude_code import (
     get_running_claude_sessions,
 )
 from .constants import (
+    DASHBOARD_CONFIG_PATH,
     PYPI_FETCH_TIMEOUT,
     PYPI_PACKAGE_URL,
     RECENT_ACTIVITY_MAX_LEN,
@@ -65,6 +66,7 @@ from .schemas import (
     ServerInfoResponse,
     SessionDetailResponse,
     SessionResponse,
+    SettingsResponse,
     VersionResponse,
 )
 from .sync import export_sessions, read_remote_sessions, resolve_sync_folder
@@ -770,6 +772,82 @@ def api_autostart_enable(request: Request):
         return {"success": True, "message": "Autostart enabled."}
     except OSError as e:
         return {"success": False, "message": f"Failed: {e}"}
+
+
+@app.post("/api/autostart/disable", response_model=ActionResponse)
+def api_autostart_disable():
+    """Disable autostart by removing the Windows HKCU Run registry value."""
+    if sys.platform != "win32":
+        return {"success": False, "message": "Autostart is only supported on Windows."}
+
+    import winreg
+
+    try:
+        with winreg.OpenKey(winreg.HKEY_CURRENT_USER, _RUN_KEY, 0, winreg.KEY_SET_VALUE) as key:
+            winreg.DeleteValue(key, _AUTOSTART_VALUE_NAME)
+        return {"success": True, "message": "Autostart disabled."}
+    except FileNotFoundError:
+        return {"success": True, "message": "Autostart was already disabled."}
+    except OSError as e:
+        return {"success": False, "message": f"Failed: {e}"}
+
+
+# ── Settings (sync toggle) ──────────────────────────────────────────────────
+
+
+def _read_dashboard_config() -> dict:
+    """Read the full dashboard-config.json, returning {} on error."""
+    if not os.path.exists(DASHBOARD_CONFIG_PATH):
+        return {}
+    try:
+        with open(DASHBOARD_CONFIG_PATH, encoding="utf-8") as f:
+            result: dict = json.load(f)
+            return result
+    except Exception:
+        return {}
+
+
+def _write_dashboard_config(cfg: dict) -> None:
+    """Write dashboard-config.json atomically."""
+    os.makedirs(os.path.dirname(DASHBOARD_CONFIG_PATH), exist_ok=True)
+    tmp = DASHBOARD_CONFIG_PATH + ".tmp"
+    with open(tmp, "w", encoding="utf-8") as f:
+        json.dump(cfg, f, indent=2)
+    os.replace(tmp, DASHBOARD_CONFIG_PATH)
+
+
+def _reload_sync_folder() -> None:
+    """Re-resolve the sync folder after a settings change."""
+    global _sync_folder
+    _sync_folder = resolve_sync_folder()
+
+
+@app.get("/api/settings", response_model=SettingsResponse)
+def api_get_settings():
+    """Return current dashboard settings (sync toggle state)."""
+    cfg = _read_dashboard_config()
+    sync_cfg = cfg.get("sync", {})
+    sync_enabled = sync_cfg.get("enabled", True) if isinstance(sync_cfg, dict) else True
+    return {"sync_enabled": sync_enabled}
+
+
+@app.put("/api/settings", response_model=SettingsResponse)
+async def api_put_settings(request: Request):
+    """Update dashboard settings (currently just the sync toggle)."""
+    body = await request.json()
+    cfg = _read_dashboard_config()
+
+    if "sync_enabled" in body:
+        if "sync" not in cfg or not isinstance(cfg.get("sync"), dict):
+            cfg["sync"] = {}
+        cfg["sync"]["enabled"] = bool(body["sync_enabled"])
+
+    _write_dashboard_config(cfg)
+    _reload_sync_folder()
+
+    sync_cfg = cfg.get("sync", {})
+    sync_enabled = sync_cfg.get("enabled", True) if isinstance(sync_cfg, dict) else True
+    return {"sync_enabled": sync_enabled}
 
 
 # ── PWA / static routes ─────────────────────────────────────────────────────

--- a/src/schemas.py
+++ b/src/schemas.py
@@ -144,3 +144,9 @@ class AutostartStatusResponse(BaseModel):
 
     supported: bool
     enabled: bool
+
+
+class SettingsResponse(BaseModel):
+    """Response for GET/PUT /api/settings — dashboard configuration."""
+
+    sync_enabled: bool = True


### PR DESCRIPTION
Adds a hamburger menu to the header with: Start on login toggle (Windows), Remote sync toggle, and About modal (restored from legacy What is this popup). Backend: /api/autostart/disable, GET/PUT /api/settings, SettingsResponse schema. Frontend: HamburgerMenu component, useSettings hook, updated useAutostart hook, toggle CSS. Removed What is this inline link. Trimmed README.