### PR TITLE
Release v0.9.0: group-by, UI polish, and expanded test coverage

### DIFF
--- a/frontend/src/components/DetailModal.tsx
+++ b/frontend/src/components/DetailModal.tsx
@@ -38,16 +38,13 @@ export default function DetailModal({
     <div className="detail-modal-overlay open" onClick={handleOverlayClick}>
       <div className="detail-modal">
         <div className="detail-modal-header">
-          <h2>{title}</h2>
+          <h2>{isRunning && s?.intent ? `🤖 ${title}` : title}</h2>
           <button className="close-x" onClick={onClose}>✕</button>
         </div>
 
         {/* Summary section */}
         {s && (
-          <div className="detail-section" style={{ marginBottom: 12 }}>
-            {isRunning && s.intent && (
-              <div style={{ fontWeight: 600, marginBottom: 4 }}>🤖 {s.intent}</div>
-            )}
+          <div className="detail-section" style={{ marginBottom: 14 }}>
             {s.branch && (
               <div style={{ marginBottom: 4 }}>
                 <span className="branch-badge">

--- a/frontend/src/components/SessionCard.tsx
+++ b/frontend/src/components/SessionCard.tsx
@@ -89,7 +89,7 @@ export default function SessionCard({ session: s, processInfo }: SessionCardProp
               {(isRunning || isRemote) && s.intent ? `🤖 ${s.intent}` : s.summary || "(Untitled session)"}
             </div>
             {isRunning && processInfo!.yolo && (
-              <span className="badge badge-yolo" style={{ flexShrink: 0 }}>🔥 YOLO</span>
+              <span className="badge badge-yolo" style={{ flexShrink: 0 }} data-tip="YOLO mode enabled">🔥 YOLO</span>
             )}
             {isRemote && (
               <span className="badge badge-mcp" style={{ flexShrink: 0 }} data-tip={`Remote machine: ${s.machine_name}`}>

--- a/frontend/src/components/SessionGrid.tsx
+++ b/frontend/src/components/SessionGrid.tsx
@@ -19,11 +19,14 @@ interface SessionGridProps {
 }
 
 export default function SessionGrid({ sessions, processes, isActive }: SessionGridProps) {
-  const { starredSessions, groupBy, collapsedGroups } = useAppState();
+  const { starredSessions, groupBy, collapsedGroups, lastFetchedAt } = useAppState();
   const dispatch = useAppDispatch();
   const [modalSession, setModalSession] = useState<{ id: string; title: string } | null>(null);
 
   if (sessions.length === 0) {
+    if (isActive && lastFetchedAt === null) {
+      return <div className="loading">Loading sessions…</div>;
+    }
     return (
       <div className="empty">
         {isActive ? "No active sessions detected." : "No previous sessions."}

--- a/frontend/src/components/SessionList.tsx
+++ b/frontend/src/components/SessionList.tsx
@@ -17,10 +17,13 @@ interface SessionListProps {
 }
 
 export default function SessionList({ sessions, processes, isActive, panelId }: SessionListProps) {
-  const { collapsedGroups, starredSessions, groupBy } = useAppState();
+  const { collapsedGroups, starredSessions, groupBy, lastFetchedAt } = useAppState();
   const dispatch = useAppDispatch();
 
   if (sessions.length === 0) {
+    if (isActive && lastFetchedAt === null) {
+      return <div className="loading">Loading sessions…</div>;
+    }
     return (
       <div className="empty">
         {isActive ? "No active sessions detected." : "No previous sessions."}

--- a/frontend/src/components/SessionTile.tsx
+++ b/frontend/src/components/SessionTile.tsx
@@ -4,7 +4,7 @@
 
 import type { Session, ProcessInfo } from "../types";
 import { COPY_FEEDBACK_MS } from "../constants";
-import { STATE_LABELS, STATE_BADGE_CLASS, TILE_STATE_CLASS } from "../utils";
+import { TILE_STATE_CLASS } from "../utils";
 import { useAppState, useAppDispatch } from "../state";
 import { focusSession, killSession } from "../api";
 import { showToast } from "./Toast";
@@ -27,8 +27,9 @@ export default function SessionTile({ session: s, processInfo, onOpenDetail }: S
   const isStarred = starredSessions.has(s.id);
   const tileClass = (isRunning || isRemote) ? (TILE_STATE_CLASS[state] || "") : "";
 
+  const displayTitle = (isRunning || isRemote) && s.intent ? s.intent : s.summary || "(Untitled)";
   const handleClick = () => {
-    if (!isRemote) onOpenDetail(s.id, s.summary || "(Untitled)");
+    if (!isRemote) onOpenDetail(s.id, displayTitle);
   };
   const stop = (e: React.MouseEvent) => e.stopPropagation();
 
@@ -79,7 +80,7 @@ export default function SessionTile({ session: s, processInfo, onOpenDetail }: S
           </div>
         )}
         {isRunning && processInfo!.yolo && (
-          <span className="badge badge-yolo" style={{ flexShrink: 0 }}>🔥</span>
+          <span className="badge badge-yolo" style={{ flexShrink: 0 }} data-tip="YOLO mode enabled">🔥</span>
         )}
       </div>
 
@@ -112,11 +113,7 @@ export default function SessionTile({ session: s, processInfo, onOpenDetail }: S
 
       {/* Badge row */}
       <div className="tile-meta">
-        {(isRunning || isRemote) && state && state !== "unknown" && (
-          <span className={`badge ${STATE_BADGE_CLASS[state] || "badge-active"}`}>
-            {STATE_LABELS[state] || state}
-          </span>
-        )}
+        {/* State is already shown by the live-dot — no badge needed here */}
         {isRunning && processInfo!.bg_tasks > 0 && (
           <BgTaskPopover
             count={processInfo!.bg_tasks}

--- a/frontend/src/test/components.test.tsx
+++ b/frontend/src/test/components.test.tsx
@@ -149,6 +149,31 @@ describe("SessionCard", () => {
     renderWithProvider(<SessionCard session={s} processInfo={undefined} />);
     expect(screen.getByText(/org\/repo\/main/)).toBeInTheDocument();
   });
+
+  it("copies restart command on copy button click", () => {
+    const s = makeSession({ restart_cmd: "copilot resume --session=card-abc" });
+    renderWithProvider(<SessionCard session={s} processInfo={undefined} />);
+    const copyBtn = screen.getByText("📋 Copy");
+    fireEvent.click(copyBtn);
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith("copilot resume --session=card-abc");
+  });
+
+  it("copies session ID on ID button click", () => {
+    const s = makeSession({ id: "card-sess-id" });
+    renderWithProvider(<SessionCard session={s} processInfo={undefined} />);
+    const idBtn = screen.getByText("🪪");
+    fireEvent.click(idBtn);
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith("card-sess-id");
+  });
+
+  it("toggles star when star button clicked", () => {
+    const s = makeSession();
+    const { container } = renderWithProvider(<SessionCard session={s} processInfo={undefined} />);
+    const starBtn = container.querySelector(".star-btn")!;
+    expect(starBtn.textContent).toBe("☆");
+    fireEvent.click(starBtn);
+    expect(starBtn.textContent).toBe("⭐");
+  });
 });
 
 // ── SessionTile ──────────────────────────────────────────────────────────────
@@ -211,9 +236,67 @@ describe("SessionTile", () => {
     expect(screen.getByText(/PID 42/)).toBeInTheDocument();
     expect(screen.getByText("✕")).toBeInTheDocument();
   });
+
+  it("calls onOpenDetail when tile clicked", () => {
+    const s = makeSession({ id: "click-id", summary: "Click me" });
+    const { container } = renderWithProvider(
+      <SessionTile session={s} processInfo={undefined} onOpenDetail={onOpenDetail} />,
+    );
+    fireEvent.click(container.querySelector(".tile-card")!);
+    expect(onOpenDetail).toHaveBeenCalledWith("click-id", "Click me");
+  });
+
+  it("does not call onOpenDetail for remote session", () => {
+    const s = makeSession({ id: "remote-1", machine_name: "remote-host" });
+    const { container } = renderWithProvider(
+      <SessionTile session={s} processInfo={undefined} onOpenDetail={onOpenDetail} />,
+    );
+    fireEvent.click(container.querySelector(".tile-card")!);
+    expect(onOpenDetail).not.toHaveBeenCalled();
+  });
+
+  it("copies restart command on copy button click", () => {
+    const s = makeSession({ restart_cmd: "copilot resume --session=abc" });
+    renderWithProvider(
+      <SessionTile session={s} processInfo={undefined} onOpenDetail={onOpenDetail} />,
+    );
+    const copyBadge = screen.getAllByText("📋")[0];
+    fireEvent.click(copyBadge);
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith("copilot resume --session=abc");
+  });
+
+  it("copies session ID on ID button click", () => {
+    const s = makeSession({ id: "sess-id-copy" });
+    renderWithProvider(
+      <SessionTile session={s} processInfo={undefined} onOpenDetail={onOpenDetail} />,
+    );
+    const idBadge = screen.getAllByText("🪪")[0];
+    fireEvent.click(idBadge);
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith("sess-id-copy");
+  });
+
+  it("toggles star when star button clicked", () => {
+    const s = makeSession({ id: "star-test" });
+    const { container } = renderWithProvider(
+      <SessionTile session={s} processInfo={undefined} onOpenDetail={onOpenDetail} />,
+    );
+    const starBtn = container.querySelector(".star-btn")!;
+    expect(starBtn.textContent).toBe("☆");
+    fireEvent.click(starBtn);
+    expect(starBtn.textContent).toBe("⭐");
+  });
+
+  it("does not show window_title when it matches intent", () => {
+    const s = makeSession({ intent: "Fixing auth" });
+    const p = makeProcess({ window_title: "🤖 Fixing auth" });
+    const { container } = renderWithProvider(
+      <SessionTile session={s} processInfo={p} onOpenDetail={onOpenDetail} />,
+    );
+    expect(container.querySelector("[data-tip^='Window:']")).toBeNull();
+  });
 });
 
-// ── SessionList ──────────────────────────────────────────────────────────────
+// ── SessionList──────────────────────────────────────────────────────────────
 
 import SessionList from "../components/SessionList";
 
@@ -222,7 +305,8 @@ describe("SessionList", () => {
     renderWithProvider(
       <SessionList sessions={[]} processes={{}} isActive={true} panelId="active" />,
     );
-    expect(screen.getByText("No active sessions detected.")).toBeInTheDocument();
+    // Before first fetch completes, active tab shows loading state
+    expect(screen.getByText("Loading sessions…")).toBeInTheDocument();
   });
 
   it("renders empty message for previous when no sessions", () => {
@@ -629,15 +713,6 @@ describe("SessionTile — interactions", () => {
       <SessionTile session={s} processInfo={p} onOpenDetail={onOpenDetail} />,
     );
     expect(screen.getByText(/Awaiting review/)).toBeInTheDocument();
-  });
-
-  it("shows state badge when running with known state", () => {
-    const s = makeSession();
-    const p = makeProcess({ state: "thinking" });
-    renderWithProvider(
-      <SessionTile session={s} processInfo={p} onOpenDetail={onOpenDetail} />,
-    );
-    expect(screen.getByText(/Thinking/)).toBeInTheDocument();
   });
 
   it("shows checkpoint count when > 0", () => {
@@ -1077,5 +1152,84 @@ describe("SessionDetail", () => {
     await waitFor(() => {
       expect(screen.getByText(/\.\.\./)).toBeInTheDocument();
     });
+  });
+});
+
+// ── SessionGrid ──────────────────────────────────────────────────────────────
+
+import SessionGrid from "../components/SessionGrid";
+
+describe("SessionGrid", () => {
+  it("renders empty message for active when no sessions", () => {
+    renderWithProvider(<SessionGrid sessions={[]} processes={{}} isActive={true} />);
+    // Before first fetch completes, active tab shows loading state
+    expect(screen.getByText("Loading sessions…")).toBeInTheDocument();
+  });
+
+  it("renders empty message for previous when no sessions", () => {
+    renderWithProvider(<SessionGrid sessions={[]} processes={{}} isActive={false} />);
+    expect(screen.getByText("No previous sessions.")).toBeInTheDocument();
+  });
+
+  it("renders tiles for sessions", () => {
+    const sessions = [
+      makeSession({ id: "s1", summary: "First session" }),
+      makeSession({ id: "s2", summary: "Second session" }),
+    ];
+    renderWithProvider(<SessionGrid sessions={sessions} processes={{}} isActive={true} />);
+    expect(screen.getByText("First session")).toBeInTheDocument();
+    expect(screen.getByText("Second session")).toBeInTheDocument();
+  });
+
+  it("shows group headers when groupBy is project", () => {
+    store["dash-group-by"] = "project";
+    const sessions = [
+      makeSession({ id: "s1", summary: "S1", group: "ProjectA" }),
+      makeSession({ id: "s2", summary: "S2", group: "ProjectB" }),
+    ];
+    renderWithProvider(<SessionGrid sessions={sessions} processes={{}} isActive={true} />);
+    expect(screen.getByText(/ProjectA/)).toBeInTheDocument();
+    expect(screen.getByText(/ProjectB/)).toBeInTheDocument();
+    const counts = screen.getAllByText("(1)");
+    expect(counts.length).toBe(2);
+  });
+
+  it("shows group headers when groupBy is machine", () => {
+    store["dash-group-by"] = "machine";
+    const sessions = [
+      makeSession({ id: "s1", summary: "S1", machine_name: "Desktop" }),
+      makeSession({ id: "s2", summary: "S2", machine_name: "Laptop" }),
+    ];
+    const { container } = renderWithProvider(<SessionGrid sessions={sessions} processes={{}} isActive={true} />);
+    const headers = container.querySelectorAll(".group-header");
+    expect(headers.length).toBe(2);
+    const headerTexts = Array.from(headers).map((h) => h.textContent);
+    expect(headerTexts.some((t) => t?.includes("Desktop"))).toBe(true);
+    expect(headerTexts.some((t) => t?.includes("Laptop"))).toBe(true);
+  });
+
+  it("does not show group headers when groupBy is none", () => {
+    const sessions = [
+      makeSession({ id: "s1", summary: "S1", group: "SameGroup" }),
+      makeSession({ id: "s2", summary: "S2", group: "SameGroup" }),
+    ];
+    const { container } = renderWithProvider(
+      <SessionGrid sessions={sessions} processes={{}} isActive={true} />,
+    );
+    expect(container.querySelector(".group-header")).toBeNull();
+  });
+
+  it("collapses group when header clicked", () => {
+    store["dash-group-by"] = "project";
+    const sessions = [
+      makeSession({ id: "s1", summary: "Visible session", group: "MyGroup" }),
+    ];
+    const { container } = renderWithProvider(
+      <SessionGrid sessions={sessions} processes={{}} isActive={true} />,
+    );
+    expect(screen.getByText("Visible session")).toBeInTheDocument();
+    const header = container.querySelector(".group-header")!;
+    fireEvent.click(header);
+    expect(screen.queryByText("Visible session")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/test/reducer.test.ts
+++ b/frontend/src/test/reducer.test.ts
@@ -45,6 +45,22 @@ describe("initialState()", () => {
     const s = initialState();
     expect(s.currentView).toBe("list");
   });
+
+  it("defaults groupBy to none", () => {
+    expect(state.groupBy).toBe("none");
+  });
+
+  it("reads groupBy preference from localStorage", () => {
+    store["dash-group-by"] = "machine";
+    const s = initialState();
+    expect(s.groupBy).toBe("machine");
+  });
+
+  it("ignores invalid groupBy in localStorage", () => {
+    store["dash-group-by"] = "invalid";
+    const s = initialState();
+    expect(s.groupBy).toBe("none");
+  });
 });
 
 describe("appReducer", () => {
@@ -106,6 +122,22 @@ describe("appReducer", () => {
   it("SET_SERVER_PID stores pid", () => {
     const next = appReducer(state, { type: "SET_SERVER_PID", pid: 9999 });
     expect(next.serverPid).toBe(9999);
+  });
+
+  it("SET_GROUP_BY changes groupBy", () => {
+    const next = appReducer(state, { type: "SET_GROUP_BY", groupBy: "project" });
+    expect(next.groupBy).toBe("project");
+  });
+
+  it("SET_GROUP_BY to machine", () => {
+    const next = appReducer(state, { type: "SET_GROUP_BY", groupBy: "machine" });
+    expect(next.groupBy).toBe("machine");
+  });
+
+  it("SET_GROUP_BY back to none", () => {
+    let next = appReducer(state, { type: "SET_GROUP_BY", groupBy: "project" });
+    next = appReducer(next, { type: "SET_GROUP_BY", groupBy: "none" });
+    expect(next.groupBy).toBe("none");
   });
 });
 

--- a/frontend/src/themes.css
+++ b/frontend/src/themes.css
@@ -311,11 +311,11 @@ button.hamburger-item {
 
 /* ===== GROUPS ===== */
 .group {
-  margin-bottom: 20px; border: 1px solid var(--group-border);
+  margin-bottom: 12px; border: 1px solid var(--group-border);
   border-radius: 10px; overflow: hidden;
 }
 .group-header {
-  background: var(--surface); padding: 12px 18px; font-weight: 600; font-size: 16px;
+  background: var(--surface); padding: 8px 18px; font-weight: 600; font-size: 16px;
   display: flex; align-items: center; gap: 8px;
   border-bottom: 1px solid var(--group-border); cursor: pointer; user-select: none;
 }
@@ -521,6 +521,9 @@ button.hamburger-item {
 
 /* ===== VIEW TOGGLE ===== */
 .view-toggle { display: flex; gap: 4px; }
+.view-toggle .palette-select {
+  color: var(--text2); font-size: 14px;
+}
 .view-btn {
   background: var(--surface2); border: 1px solid var(--border); color: var(--text2);
   border-radius: 6px; padding: 5px 12px; font-size: 14px; cursor: pointer;
@@ -552,7 +555,7 @@ button.hamburger-item {
   padding: 24px; max-width: 700px; width: 95%; max-height: 80vh; overflow-y: auto;
   box-shadow: 0 16px 48px rgba(0,0,0,0.3);
 }
-.detail-modal-header { display: flex; align-items: center; gap: 10px; margin-bottom: 16px; }
+.detail-modal-header { display: flex; align-items: center; gap: 10px; margin-bottom: 4px; }
 .detail-modal-header h2 { font-size: 18px; flex: 1; }
 .detail-modal-header .close-x {
   background: none; border: none; color: var(--text2); font-size: 22px;

--- a/frontend/src/themes.css
+++ b/frontend/src/themes.css
@@ -482,7 +482,7 @@ button.hamburger-item {
 /* ===== TILE VIEW ===== */
 .tile-grid {
   display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-  gap: 12px;
+  gap: 12px; margin: 12px 0;
 }
 .tile-card {
   background: var(--surface); border: 1px solid var(--border); border-radius: 10px;

--- a/src/__version__.py
+++ b/src/__version__.py
@@ -1,4 +1,4 @@
 """Version information for Copilot Dashboard."""
 
-__version__ = "0.8.1"
+__version__ = "0.9.0"
 __repository__ = "https://github.com/JeffSteinbok/ghcpCliDashboard"

--- a/src/dashboard_api.py
+++ b/src/dashboard_api.py
@@ -364,11 +364,15 @@ def _sessions_from_events() -> list[dict]:
 
                         etype = evt.get("type", "")
 
-                        if etype in ("session.start", "session.resume") and not cwd:
+                        if etype in ("session.start", "session.resume"):
                             ctx = evt.get("data", {}).get("context", {})
-                            cwd = ctx.get("cwd", "")
-                            branch = ctx.get("branch", "")
-                            repository = ctx.get("repository", "")
+                            # Always overwrite so the latest resume context wins
+                            if ctx.get("cwd"):
+                                cwd = ctx["cwd"]
+                            if ctx.get("branch"):
+                                branch = ctx["branch"]
+                            if ctx.get("repository"):
+                                repository = ctx["repository"]
 
                         elif etype == "user.message" and not summary:
                             content = evt.get("data", {}).get("content", "")

--- a/src/grouping.py
+++ b/src/grouping.py
@@ -85,6 +85,11 @@ def get_group_name(session: dict) -> str:
 
     # --- 3. CWD-based: last meaningful directory segment ---
     if cwd:
+        # If the CWD is the user's home directory, use a friendly label
+        home = os.path.expanduser("~").replace("\\", "/").rstrip("/")
+        if cwd.rstrip("/").lower() == home.lower():
+            return "🏠 Home"
+
         skip = SKIP_DIRS | {d.lower() for d in extra_skip}
         parts = cwd.rstrip("/").split("/")
         # Filter out drive letters, common dirs, and user-configured skips

--- a/src/process_tracker.py
+++ b/src/process_tracker.py
@@ -638,13 +638,17 @@ def _read_event_data(session_id) -> EventData:
                     continue
 
                 # Fast string pre-checks to avoid JSON parsing every line
-                if ('"session.start"' in line or '"session.resume"' in line) and not result.cwd:
+                if '"session.start"' in line or '"session.resume"' in line:
                     try:
                         evt = json.loads(line)
                         ctx = evt.get("data", {}).get("context", {})
-                        result.cwd = ctx.get("cwd", "")
-                        result.branch = ctx.get("branch", "")
-                        result.repository = ctx.get("repository", "")
+                        # Always overwrite so the latest resume context wins
+                        if ctx.get("cwd"):
+                            result.cwd = ctx["cwd"]
+                        if ctx.get("branch"):
+                            result.branch = ctx["branch"]
+                        if ctx.get("repository"):
+                            result.repository = ctx["repository"]
                     except json.JSONDecodeError:
                         pass
                     continue

--- a/tests/test_grouping.py
+++ b/tests/test_grouping.py
@@ -3,11 +3,8 @@
 import json
 from unittest.mock import patch
 
-import pytest
-
 from src.constants import DEFAULT_GROUP_NAME
 from src.grouping import _load_config, get_group_name
-
 
 # ---------------------------------------------------------------------------
 # _load_config (covers lines 38-43)
@@ -102,3 +99,25 @@ class TestGetGroupName:
             session = {"cwd": None, "repository": None, "summary": None}
             result = get_group_name(session)
         assert result == DEFAULT_GROUP_NAME
+
+    def test_home_directory_returns_home_label(self, tmp_path):
+        """CWD matching the user's home directory should return '🏠 Home'."""
+        import os
+
+        missing = str(tmp_path / "nonexistent.json")
+        home = os.path.expanduser("~").replace("\\", "/")
+        with patch("src.grouping.DASHBOARD_CONFIG_PATH", missing):
+            session = {"cwd": home, "repository": "", "summary": ""}
+            result = get_group_name(session)
+        assert result == "🏠 Home"
+
+    def test_home_directory_windows_path(self, tmp_path):
+        """Windows-style home path (backslashes) should also match."""
+        import os
+
+        missing = str(tmp_path / "nonexistent.json")
+        home = os.path.expanduser("~")  # native path (backslashes on Windows)
+        with patch("src.grouping.DASHBOARD_CONFIG_PATH", missing):
+            session = {"cwd": home, "repository": "", "summary": ""}
+            result = get_group_name(session)
+        assert result == "🏠 Home"

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1,0 +1,397 @@
+"""Tests for sync.py — cross-machine session sync."""
+
+import json
+import time
+from datetime import UTC, datetime
+from unittest.mock import patch
+
+from src.sync import (
+    cleanup_stale_sessions,
+    export_sessions,
+    get_machine_name,
+    read_remote_sessions,
+    resolve_sync_folder,
+    sync_config_from_shared,
+    sync_config_to_shared,
+)
+
+MACHINE = "test-host"
+
+
+# ── get_machine_name ─────────────────────────────────────────────────────────
+
+
+class TestGetMachineName:
+    def test_returns_non_empty_string(self):
+        name = get_machine_name()
+        assert isinstance(name, str)
+        assert len(name) > 0
+
+
+# ── resolve_sync_folder ─────────────────────────────────────────────────────
+
+
+class TestResolveSyncFolder:
+    def test_returns_none_when_sync_disabled(self, tmp_path):
+        config = {"sync": {"enabled": False}}
+        config_file = tmp_path / "dashboard-config.json"
+        config_file.write_text(json.dumps(config))
+        with patch("src.sync.DASHBOARD_CONFIG_PATH", str(config_file)):
+            result = resolve_sync_folder()
+        assert result is None
+
+    def test_returns_explicit_folder(self, tmp_path):
+        sync_root = tmp_path / "my-sync"
+        sync_root.mkdir()
+        config = {"sync": {"folder": str(sync_root)}}
+        config_file = tmp_path / "dashboard-config.json"
+        config_file.write_text(json.dumps(config))
+        with patch("src.sync.DASHBOARD_CONFIG_PATH", str(config_file)):
+            result = resolve_sync_folder()
+        assert result is not None
+        assert result == sync_root / "CopilotDashboard"
+
+    def test_returns_none_when_explicit_folder_missing(self, tmp_path):
+        config = {"sync": {"folder": str(tmp_path / "no-such-dir")}}
+        config_file = tmp_path / "dashboard-config.json"
+        config_file.write_text(json.dumps(config))
+        with patch("src.sync.DASHBOARD_CONFIG_PATH", str(config_file)):
+            result = resolve_sync_folder()
+        assert result is None
+
+    def test_returns_onedrive_commercial_when_env_set(self, tmp_path):
+        onedrive = tmp_path / "OneDrive"
+        onedrive.mkdir()
+        config_file = tmp_path / "empty-config.json"
+        # no sync config → falls through to env vars
+        config_file.write_text("{}")
+        env = {"OneDriveCommercial": str(onedrive)}
+        with (
+            patch("src.sync.DASHBOARD_CONFIG_PATH", str(config_file)),
+            patch.dict("os.environ", env, clear=False),
+        ):
+            # Ensure Path.is_dir works on our temp dir
+            result = resolve_sync_folder()
+        assert result is not None
+        assert result == onedrive / "CopilotDashboard"
+
+    def test_falls_back_to_documents(self, tmp_path):
+        docs = tmp_path / "Documents"
+        docs.mkdir()
+        config_file = tmp_path / "empty-config.json"
+        config_file.write_text("{}")
+        env = {"OneDriveCommercial": "", "OneDriveConsumer": ""}
+        with (
+            patch("src.sync.DASHBOARD_CONFIG_PATH", str(config_file)),
+            patch.dict("os.environ", env, clear=False),
+            patch("src.sync.Path.home", return_value=tmp_path),
+        ):
+            result = resolve_sync_folder()
+        assert result is not None
+        assert result == docs / "CopilotDashboard"
+
+    def test_returns_none_when_no_suitable_folder(self, tmp_path):
+        # No Documents folder, no OneDrive, no config
+        config_file = tmp_path / "empty-config.json"
+        config_file.write_text("{}")
+        env = {"OneDriveCommercial": "", "OneDriveConsumer": ""}
+        fake_home = tmp_path / "fakehome"
+        fake_home.mkdir()
+        with (
+            patch("src.sync.DASHBOARD_CONFIG_PATH", str(config_file)),
+            patch.dict("os.environ", env, clear=False),
+            patch("src.sync.Path.home", return_value=fake_home),
+        ):
+            result = resolve_sync_folder()
+        assert result is None
+
+
+# ── export_sessions ──────────────────────────────────────────────────────────
+
+
+class TestExportSessions:
+    def test_creates_machine_directory_structure(self, tmp_path):
+        sync_folder = tmp_path / "sync"
+        sync_folder.mkdir()
+        with patch("src.sync.get_machine_name", return_value=MACHINE):
+            export_sessions([], sync_folder)
+        assert (sync_folder / MACHINE / "sessions").is_dir()
+        assert (sync_folder / MACHINE / "machine.json").is_file()
+
+    def test_writes_session_json_files(self, tmp_path):
+        sync_folder = tmp_path / "sync"
+        sync_folder.mkdir()
+        sessions = [
+            {"id": "sess-1", "cwd": "/project", "summary": "test"},
+            {"id": "sess-2", "cwd": "/other", "summary": "other"},
+        ]
+        with patch("src.sync.get_machine_name", return_value=MACHINE):
+            export_sessions(sessions, sync_folder)
+
+        sessions_dir = sync_folder / MACHINE / "sessions"
+        assert (sessions_dir / "sess-1.json").is_file()
+        assert (sessions_dir / "sess-2.json").is_file()
+
+        data = json.loads((sessions_dir / "sess-1.json").read_text())
+        assert data["id"] == "sess-1"
+        assert data["machine_name"] == MACHINE
+
+    def test_writes_machine_json_with_metadata(self, tmp_path):
+        sync_folder = tmp_path / "sync"
+        sync_folder.mkdir()
+        sessions = [{"id": "s1", "cwd": "/a"}]
+        with patch("src.sync.get_machine_name", return_value=MACHINE):
+            export_sessions(sessions, sync_folder)
+
+        info = json.loads((sync_folder / MACHINE / "machine.json").read_text())
+        assert info["hostname"] == MACHINE
+        assert info["active_session_count"] == 1
+
+    def test_skips_sessions_with_empty_id(self, tmp_path):
+        sync_folder = tmp_path / "sync"
+        sync_folder.mkdir()
+        sessions = [
+            {"id": "", "cwd": "/a"},
+            {"id": "valid", "cwd": "/b"},
+        ]
+        with patch("src.sync.get_machine_name", return_value=MACHINE):
+            export_sessions(sessions, sync_folder)
+
+        sessions_dir = sync_folder / MACHINE / "sessions"
+        files = list(sessions_dir.glob("*.json"))
+        assert len(files) == 1
+        assert files[0].name == "valid.json"
+
+    def test_cleans_up_stale_session_files(self, tmp_path):
+        sync_folder = tmp_path / "sync"
+        sessions_dir = sync_folder / MACHINE / "sessions"
+        sessions_dir.mkdir(parents=True)
+        # Pre-existing stale file
+        (sessions_dir / "old-session.json").write_text("{}")
+
+        sessions = [{"id": "new-session", "cwd": "/a"}]
+        with patch("src.sync.get_machine_name", return_value=MACHINE):
+            export_sessions(sessions, sync_folder)
+
+        assert not (sessions_dir / "old-session.json").exists()
+        assert (sessions_dir / "new-session.json").exists()
+
+
+# ── cleanup_stale_sessions ───────────────────────────────────────────────────
+
+
+class TestCleanupStaleSessions:
+    def test_removes_files_not_in_active_ids(self, tmp_path):
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        (sessions_dir / "keep.json").write_text("{}")
+        (sessions_dir / "remove.json").write_text("{}")
+
+        cleanup_stale_sessions({"keep"}, sessions_dir)
+
+        assert (sessions_dir / "keep.json").exists()
+        assert not (sessions_dir / "remove.json").exists()
+
+    def test_keeps_files_in_active_ids(self, tmp_path):
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        (sessions_dir / "a.json").write_text("{}")
+        (sessions_dir / "b.json").write_text("{}")
+
+        cleanup_stale_sessions({"a", "b"}, sessions_dir)
+
+        assert (sessions_dir / "a.json").exists()
+        assert (sessions_dir / "b.json").exists()
+
+    def test_noop_when_dir_missing(self, tmp_path):
+        missing = tmp_path / "nonexistent"
+        # Should not raise
+        cleanup_stale_sessions(set(), missing)
+
+
+# ── read_remote_sessions ─────────────────────────────────────────────────────
+
+
+class TestReadRemoteSessions:
+    def test_returns_empty_when_sync_folder_missing(self, tmp_path):
+        missing = tmp_path / "nonexistent"
+        result = read_remote_sessions(missing)
+        assert result == []
+
+    def test_skips_local_machine(self, tmp_path):
+        sync_folder = tmp_path / "sync"
+        local_dir = sync_folder / MACHINE
+        sessions_dir = local_dir / "sessions"
+        sessions_dir.mkdir(parents=True)
+        (sessions_dir / "s1.json").write_text(json.dumps({"id": "s1"}))
+        machine_info = {"last_sync": datetime.now(UTC).isoformat()}
+        (local_dir / "machine.json").write_text(json.dumps(machine_info))
+
+        with patch("src.sync.get_machine_name", return_value=MACHINE):
+            result = read_remote_sessions(sync_folder)
+        assert result == []
+
+    def test_reads_sessions_from_other_machines(self, tmp_path):
+        sync_folder = tmp_path / "sync"
+        remote_dir = sync_folder / "remote-host"
+        sessions_dir = remote_dir / "sessions"
+        sessions_dir.mkdir(parents=True)
+
+        session_data = {"id": "r1", "cwd": "/remote"}
+        (sessions_dir / "r1.json").write_text(json.dumps(session_data))
+        machine_info = {"last_sync": datetime.now(UTC).isoformat()}
+        (remote_dir / "machine.json").write_text(json.dumps(machine_info))
+
+        with patch("src.sync.get_machine_name", return_value=MACHINE):
+            result = read_remote_sessions(sync_folder)
+
+        assert len(result) == 1
+        assert result[0]["id"] == "r1"
+        assert result[0]["machine_name"] == "remote-host"
+        assert result[0]["is_running"] is True
+
+    def test_skips_stale_machines(self, tmp_path):
+        sync_folder = tmp_path / "sync"
+        remote_dir = sync_folder / "stale-host"
+        sessions_dir = remote_dir / "sessions"
+        sessions_dir.mkdir(parents=True)
+        (sessions_dir / "s1.json").write_text(json.dumps({"id": "s1"}))
+
+        # Set last_sync far in the past (beyond SYNC_STALE_THRESHOLD)
+        old_time = datetime.fromtimestamp(time.time() - 99999, tz=UTC).isoformat()
+        (remote_dir / "machine.json").write_text(json.dumps({"last_sync": old_time}))
+
+        with patch("src.sync.get_machine_name", return_value=MACHINE):
+            result = read_remote_sessions(sync_folder)
+
+        assert result == []
+        # Stale dir should have been removed
+        assert not remote_dir.exists()
+
+    def test_removes_stale_machine_directories(self, tmp_path):
+        sync_folder = tmp_path / "sync"
+        stale_dir = sync_folder / "old-machine"
+        stale_dir.mkdir(parents=True)
+
+        old_time = datetime.fromtimestamp(time.time() - 99999, tz=UTC).isoformat()
+        (stale_dir / "machine.json").write_text(json.dumps({"last_sync": old_time}))
+
+        with patch("src.sync.get_machine_name", return_value=MACHINE):
+            read_remote_sessions(sync_folder)
+
+        assert not stale_dir.exists()
+
+    def test_skips_machines_without_machine_json(self, tmp_path):
+        sync_folder = tmp_path / "sync"
+        remote_dir = sync_folder / "no-machine-json"
+        sessions_dir = remote_dir / "sessions"
+        sessions_dir.mkdir(parents=True)
+        (sessions_dir / "s1.json").write_text(json.dumps({"id": "s1"}))
+
+        with patch("src.sync.get_machine_name", return_value=MACHINE):
+            result = read_remote_sessions(sync_folder)
+        assert result == []
+
+    def test_sets_machine_name_and_is_running(self, tmp_path):
+        sync_folder = tmp_path / "sync"
+        remote_dir = sync_folder / "work-laptop"
+        sessions_dir = remote_dir / "sessions"
+        sessions_dir.mkdir(parents=True)
+
+        (sessions_dir / "abc.json").write_text(json.dumps({"id": "abc"}))
+        machine_info = {"last_sync": datetime.now(UTC).isoformat()}
+        (remote_dir / "machine.json").write_text(json.dumps(machine_info))
+
+        with patch("src.sync.get_machine_name", return_value=MACHINE):
+            result = read_remote_sessions(sync_folder)
+
+        assert len(result) == 1
+        assert result[0]["machine_name"] == "work-laptop"
+        assert result[0]["is_running"] is True
+
+
+# ── sync_config_to_shared ───────────────────────────────────────────────────
+
+
+class TestSyncConfigToShared:
+    def test_copies_config_to_shared_folder(self, tmp_path):
+        local_config = tmp_path / "local-config.json"
+        local_config.write_text(json.dumps({"theme": "dark"}))
+
+        sync_folder = tmp_path / "sync"
+        sync_folder.mkdir()
+
+        with patch("src.sync.DASHBOARD_CONFIG_PATH", str(local_config)):
+            sync_config_to_shared(sync_folder)
+
+        shared = sync_folder / "config" / "dashboard-config.json"
+        assert shared.is_file()
+        assert json.loads(shared.read_text()) == {"theme": "dark"}
+
+    def test_noop_when_local_config_missing(self, tmp_path):
+        sync_folder = tmp_path / "sync"
+        sync_folder.mkdir()
+
+        with patch("src.sync.DASHBOARD_CONFIG_PATH", str(tmp_path / "missing.json")):
+            sync_config_to_shared(sync_folder)
+
+        assert not (sync_folder / "config").exists()
+
+
+# ── sync_config_from_shared ─────────────────────────────────────────────────
+
+
+class TestSyncConfigFromShared:
+    def test_imports_when_shared_is_newer(self, tmp_path):
+        local_config = tmp_path / "local-config.json"
+        local_config.write_text(json.dumps({"old": True}))
+
+        shared_dir = tmp_path / "sync" / "config"
+        shared_dir.mkdir(parents=True)
+        shared_config = shared_dir / "dashboard-config.json"
+        shared_config.write_text(json.dumps({"new": True}))
+
+        # Make shared file newer
+        import os
+
+        local_mtime = os.path.getmtime(local_config)
+        os.utime(shared_config, (local_mtime + 100, local_mtime + 100))
+
+        sync_folder = tmp_path / "sync"
+        with patch("src.sync.DASHBOARD_CONFIG_PATH", str(local_config)):
+            sync_config_from_shared(sync_folder)
+
+        assert json.loads(local_config.read_text()) == {"new": True}
+
+    def test_does_not_overwrite_when_local_is_newer(self, tmp_path):
+        local_config = tmp_path / "local-config.json"
+        local_config.write_text(json.dumps({"local": True}))
+
+        shared_dir = tmp_path / "sync" / "config"
+        shared_dir.mkdir(parents=True)
+        shared_config = shared_dir / "dashboard-config.json"
+        shared_config.write_text(json.dumps({"shared": True}))
+
+        # Make local file newer
+        import os
+
+        shared_mtime = os.path.getmtime(shared_config)
+        os.utime(local_config, (shared_mtime + 100, shared_mtime + 100))
+
+        sync_folder = tmp_path / "sync"
+        with patch("src.sync.DASHBOARD_CONFIG_PATH", str(local_config)):
+            sync_config_from_shared(sync_folder)
+
+        assert json.loads(local_config.read_text()) == {"local": True}
+
+    def test_noop_when_shared_config_missing(self, tmp_path):
+        local_config = tmp_path / "local-config.json"
+        local_config.write_text(json.dumps({"keep": True}))
+
+        sync_folder = tmp_path / "sync"
+        sync_folder.mkdir()
+
+        with patch("src.sync.DASHBOARD_CONFIG_PATH", str(local_config)):
+            sync_config_from_shared(sync_folder)
+
+        assert json.loads(local_config.read_text()) == {"keep": True}


### PR DESCRIPTION
## What's New

### Features
- **Group-by selector** — group session cards by project, machine, or no grouping (tile + list views)
- **Home directory label** — sessions started from ~ show as '🏠 Home' instead of username folder
- **Wider layout** — container max-width bumped to 1920px for ultrawide monitors

### Fixes
- Fix duplicate text in tiles when window title matches intent
- Tighter group header padding and tile grid spacing
- Group-by dropdown color now matches other view-toggle buttons

### Tests (+50 new)
- SessionGrid component tests (grouping, collapsing, empty states)
- SessionTile/SessionCard interaction tests (copy, star, kill)
- Sync module tests (27 tests covering export, import, staleness, config sync)
- Grouping Home directory tests
- Reducer groupBy state tests

**288 → 317 Python tests, 179 → 200 frontend tests — all green.**