### PR TITLE
Add Jekyll docs site with Just the Docs theme

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Build with Jekyll
         uses: actions/jekyll-build-pages@v1
         with:
-          source: ./
+          source: ./docs
           destination: ./_site
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem "jekyll-remote-theme"
+gem "github-pages", group: :jekyll_plugins

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,39 @@
+title: Copilot Session Dashboard
+description: A local web dashboard that monitors all your GitHub Copilot CLI and Claude Code sessions in real-time.
+
+remote_theme: just-the-docs/just-the-docs@v0.10.1
+
+url: "https://jeffsteinbok.github.io"
+baseurl: "/ghcpCliDashboard"
+
+color_scheme: dark
+
+aux_links:
+  "GitHub":
+    - "https://github.com/JeffSteinbok/ghcpCliDashboard"
+  "PyPI":
+    - "https://pypi.org/project/ghcp-cli-dashboard/"
+
+aux_links_new_tab: true
+
+plugins:
+  - jekyll-remote-theme
+
+nav_sort: case_insensitive
+
+heading_anchors: true
+
+back_to_top: true
+back_to_top_text: "Back to top"
+
+footer_content: >-
+  Copyright &copy; 2025 Jeff Steinbok.
+  Distributed under the <a href="https://github.com/JeffSteinbok/ghcpCliDashboard/blob/main/LICENSE">MIT License</a>.
+
+ga_tracking:
+ga_tracking_anonymize_ip: true
+
+exclude:
+  - Gemfile
+  - Gemfile.lock
+  - openapi.json

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,116 @@
+---
+title: API Reference
+layout: default
+nav_order: 6
+---
+
+# API Reference
+{: .no_toc }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+The dashboard exposes a REST API that powers the web UI. All endpoints return JSON unless otherwise noted.
+
+{: .note }
+> The full OpenAPI specification is available at [`openapi.json`](https://github.com/JeffSteinbok/ghcpCliDashboard/blob/main/docs/openapi.json). You can view it interactively in the [Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/JeffSteinbok/ghcpCliDashboard/main/docs/openapi.json).
+
+## Endpoints
+
+### Dashboard UI
+
+| Method | Endpoint | Description |
+|:-------|:---------|:------------|
+| `GET` | `/` | Serves the dashboard web UI |
+
+### Sessions
+
+| Method | Endpoint | Description |
+|:-------|:---------|:------------|
+| `GET` | `/api/sessions` | All sessions with metadata, groups, and restart commands |
+| `GET` | `/api/session/{id}` | Session detail — checkpoints, refs, recent output, turns |
+
+#### `GET /api/sessions`
+
+Returns all known sessions organized by group, including both active (running) and previous (from session store) sessions.
+
+**Response fields:**
+
+| Field | Type | Description |
+|:------|:-----|:------------|
+| `groups` | `object` | Sessions grouped by project name |
+| `active_count` | `integer` | Number of currently active sessions |
+| `previous_count` | `integer` | Number of previous sessions |
+
+#### `GET /api/session/{id}`
+
+Returns detailed information for a single session.
+
+**Response fields:**
+
+| Field | Type | Description |
+|:------|:-----|:------------|
+| `checkpoints` | `array` | Milestone summaries with titles and overviews |
+| `refs` | `array` | Linked PRs, issues, and commits |
+| `recent_output` | `string` | Latest tool output from the session |
+| `turns` | `array` | Conversation history (user messages and assistant responses) |
+
+### Processes
+
+| Method | Endpoint | Description |
+|:-------|:---------|:------------|
+| `GET` | `/api/processes` | Currently running sessions with state, yolo mode, and MCP servers |
+
+### Actions
+
+| Method | Endpoint | Description |
+|:-------|:---------|:------------|
+| `POST` | `/api/focus/{id}` | Bring a session's terminal window to the foreground |
+| `POST` | `/api/kill/{id}` | Kill a running session process |
+
+### Files
+
+| Method | Endpoint | Description |
+|:-------|:---------|:------------|
+| `GET` | `/api/files` | Most-edited files across all sessions |
+
+### Server Management
+
+| Method | Endpoint | Description |
+|:-------|:---------|:------------|
+| `GET` | `/api/version` | Current installed version + PyPI update check |
+| `POST` | `/api/update` | Trigger pip upgrade and server restart |
+| `GET` | `/api/server-info` | Server PID and port |
+
+## Using the API
+
+The API is available at `http://localhost:5111` (or your custom port) whenever the dashboard is running.
+
+### Example: Get Active Sessions
+
+```bash
+curl http://localhost:5111/api/sessions | python -m json.tool
+```
+
+### Example: Get Session Detail
+
+```bash
+curl http://localhost:5111/api/session/abc-123-def | python -m json.tool
+```
+
+### Example: Focus a Session Window
+
+```bash
+curl -X POST http://localhost:5111/api/focus/abc-123-def
+```
+
+### Example: Check Version
+
+```bash
+curl http://localhost:5111/api/version
+```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,120 @@
+---
+title: Configuration
+layout: default
+nav_order: 5
+---
+
+# Configuration
+{: .no_toc }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+## Configuration File
+
+The dashboard reads its configuration from:
+
+```
+~/.copilot/dashboard-config.json
+```
+
+All settings are optional — the dashboard works out of the box with sensible defaults.
+
+## Session Grouping
+
+Sessions are grouped by project using a smart algorithm:
+
+1. **Custom mappings** — user-defined keyword → group name
+2. **Repository field** — `owner/repo` → uses the repo name
+3. **CWD path** — last meaningful directory segment (skips common dirs like `Users`, `home`, drive letters)
+4. **Content keywords** — fallback matching on summary/checkpoint text
+
+### Custom Grouping
+
+```json
+{
+  "grouping": {
+    "skip_dirs": ["myusername"],
+    "mappings": {
+      "myrepo": "My Project",
+      "review": "Code Reviews"
+    }
+  }
+}
+```
+
+| Field | Type | Description |
+|:------|:-----|:------------|
+| `skip_dirs` | `string[]` | Directory names to skip when deriving project names from paths |
+| `mappings` | `object` | Keyword → display name mappings for grouping |
+
+## Cross-Machine Sync
+
+See active sessions from all your machines in one dashboard — powered by OneDrive, Google Drive, or any cloud-synced folder.
+
+### How It Works
+
+1. On each poll cycle, the dashboard exports your active sessions as JSON files to a shared cloud folder
+2. Other machines read those files and display them in a **"Remote Sessions"** section
+3. Each machine only writes to its own subfolder — no sync conflicts
+
+### Auto-Detection
+
+The sync folder is auto-detected in this priority order:
+
+1. `OneDriveCommercial` (preferred — prevents data leakage to personal accounts)
+2. `OneDriveConsumer`
+3. User Documents folder
+
+### Sync Configuration
+
+```json
+{
+  "sync": {
+    "enabled": true,
+    "folder": "D:\\MyCloudSync"
+  }
+}
+```
+
+| Field | Type | Default | Description |
+|:------|:-----|:--------|:------------|
+| `enabled` | `boolean` | `true` | Set to `false` to disable sync entirely |
+| `folder` | `string` | *(auto-detected)* | Override auto-detection with a specific path |
+
+### What Remote Sessions Show
+
+- ✅ Live state indicators (working, waiting, idle)
+- ✅ Session summary, intent, branch, MCP servers
+- ✅ Turn and checkpoint counts
+- ✅ Machine name badge (e.g., `🖥️ LAPTOP-HOME`)
+
+### What Remote Sessions Don't Show
+
+- ❌ Detail drill-down (checkpoints, turns, files)
+- ❌ Focus or kill actions (those are local-only)
+- ❌ Past/previous sessions from remote machines
+
+## Full Configuration Example
+
+```json
+{
+  "grouping": {
+    "skip_dirs": ["jeffs", "projects"],
+    "mappings": {
+      "ghcpCliDashboard": "Copilot Dashboard",
+      "review": "Code Reviews",
+      "docs": "Documentation"
+    }
+  },
+  "sync": {
+    "enabled": true,
+    "folder": "D:\\OneDrive\\CopilotSync"
+  }
+}
+```

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,72 @@
+---
+title: Contributing
+layout: default
+nav_order: 8
+---
+
+# Contributing
+{: .no_toc }
+
+Thank you for your interest in contributing! Here's how to get involved.
+{: .fs-6 .fw-300 }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+## Code of Conduct
+
+Be respectful and constructive. We're all here to build something useful.
+
+## Reporting Bugs
+
+Open an [issue](https://github.com/JeffSteinbok/ghcpCliDashboard/issues) with:
+
+- A clear description of the problem
+- Steps to reproduce
+- Expected vs. actual behavior
+- Your OS, Python version, and package version
+
+## Suggesting Features
+
+Open an [issue](https://github.com/JeffSteinbok/ghcpCliDashboard/issues) with the `enhancement` label and describe what you'd like and why.
+
+## Submitting Code
+
+1. **Fork** the repository and create your branch from `main`:
+   ```bash
+   git checkout -b feat/your-feature-name
+   ```
+2. Make your changes following the [Development Guide]({{ site.baseurl }}/development).
+3. Ensure all CI checks pass (lint, type check, tests):
+   ```bash
+   ruff check src/
+   ruff format src/
+   mypy src/
+   python -m pytest tests/ -v --tb=short
+   ```
+4. **Open a Pull Request** against `main` — direct pushes to `main` are not allowed.
+5. A maintainer will review your PR. Please be patient and responsive to feedback.
+
+## Branch Naming
+
+| Prefix | Use for |
+|:-------|:--------|
+| `feat/` | New features |
+| `fix/` | Bug fixes |
+| `chore/` | Maintenance, dependencies, CI |
+| `docs/` | Documentation changes |
+
+Keep PRs focused — one feature or fix per PR.
+
+## Development Setup
+
+See the [Development Guide]({{ site.baseurl }}/development) for full instructions on setting up a local dev environment, running tests, and linting.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the [MIT License](https://github.com/JeffSteinbok/ghcpCliDashboard/blob/main/LICENSE).

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,117 @@
+---
+title: Development
+layout: default
+nav_order: 7
+---
+
+# Development Guide
+{: .no_toc }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+## Setting Up
+
+```bash
+# Clone the repo
+git clone https://github.com/JeffSteinbok/ghcpCliDashboard.git
+cd ghcpCliDashboard
+
+# Install Python dev dependencies
+pip install -r requirements-dev.txt
+
+# Build the React frontend (required before starting the server)
+cd frontend
+npm install
+npm run build   # outputs to ../src/static/dist/
+cd ..
+
+# Start the dashboard on dev port
+python -m src.session_dashboard start --port 5112
+```
+
+{: .important }
+> The React frontend **must be built** before starting the server. The build output goes to `src/static/dist/` which the Python server serves as static files. If the dashboard shows a blank page, rebuild the frontend.
+
+## Architecture
+
+| Module | Role |
+|:-------|:-----|
+| `session_dashboard.py` | CLI entry point with `start`, `stop`, `status` subcommands |
+| `dashboard_api.py` | FastAPI app with typed REST API, Pydantic response models, and static file serving |
+| `schemas.py` | Pydantic response models for all API endpoints (auto-generates OpenAPI spec) |
+| `constants.py` | Centralized constants — timeouts, paths, terminal names, grouping defaults |
+| `process_tracker.py` | Detects running copilot processes, reads `events.jsonl` for session state, extracts MCP servers, and uses Win32 APIs for window focus |
+| `models.py` | Typed data models (`ProcessInfo`, `EventData`, `SessionState`, `VersionCache`, `RunningCache`) shared across modules |
+| `grouping.py` | Session grouping logic — derives project/area names from repository, CWD, or content keywords |
+
+## Data Sources
+
+| Source | What It Provides |
+|:-------|:----------------|
+| `~/.copilot/session-store.db` | Session metadata, turns, checkpoints, files, refs (read-only SQLite) |
+| `~/.copilot/session-state/<id>/events.jsonl` | Live session state, MCP config, recent tool output |
+| Running `copilot.exe` processes | Active session detection, `--yolo` flag, MCP config file paths |
+
+## Data Models
+
+The codebase uses typed dataclasses and TypedDicts (defined in `src/models.py`) instead of raw dicts:
+
+- **`ProcessInfo`** — running copilot process: pid, terminal info, state, yolo, mcp_servers
+- **`EventData`** — parsed from `events.jsonl`: mcp_servers, tool_calls, cwd, branch, intent
+- **`SessionState`** — TypedDict with state, waiting_context, bg_tasks
+- **`VersionCache`** / **`RunningCache`** — typed TTL cache structures
+
+## Frontend
+
+The frontend is a React/TypeScript app built with Vite:
+
+```
+frontend/
+├── src/
+│   ├── components/   # React components
+│   ├── hooks/        # Custom React hooks
+│   ├── types/        # TypeScript type definitions
+│   └── App.tsx       # Root component
+├── package.json
+└── vite.config.ts
+```
+
+For active frontend development, run the Vite dev server:
+
+```bash
+cd frontend
+npm run dev    # proxies API calls to http://localhost:5112
+```
+
+The Python backend must still be running on port 5112 for API calls to work.
+
+## Testing
+
+```bash
+# Run tests
+python -m pytest tests/ -v --tb=short
+
+# Run with coverage
+python -m pytest tests/ --cov=src --cov-report=term-missing
+```
+
+## Linting & Type Checking
+
+```bash
+# Lint
+ruff check src/
+
+# Format
+ruff format src/
+
+# Type check
+mypy src/
+```
+
+All three checks must pass before submitting a PR.

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,0 +1,105 @@
+---
+title: Features
+layout: default
+nav_order: 4
+---
+
+# Features
+{: .no_toc }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+## Session Monitoring
+
+The dashboard shows all your Copilot CLI and Claude Code sessions with real-time state indicators:
+
+| State | Indicator | Meaning |
+|:------|:----------|:--------|
+| **Working / Thinking** | 🟢 Green | Session is actively running tools or reasoning |
+| **Waiting** | 🟡 Yellow | Session needs your input (`ask_user` or `ask_permission` pending) |
+| **Idle** | 🔵 Blue | Session is done and ready for your next task |
+
+## Claude Code Support
+
+{: .new }
+> New in v0.7
+
+The dashboard automatically discovers **Claude Code** sessions from `~/.claude/projects/`. Active Claude sessions appear alongside Copilot sessions with a distinctive `✦ Claude` badge.
+
+## Desktop Notifications
+
+Get browser notifications when sessions transition between states — so you know immediately when a session needs attention or finishes its work.
+
+## Focus Window
+
+Click the focus button on any active session to bring its terminal window to the foreground. No more hunting through your taskbar to find the right terminal.
+
+## Restart Commands
+
+Every session shows a copy-pasteable restart command:
+
+```bash
+copilot --resume <session-id>
+```
+
+Quickly resume any session that's been interrupted.
+
+## Waiting Context
+
+When a session is in the **Waiting** state, the dashboard shows exactly *what* it's asking — the `ask_user` question, available choices, or `ask_permission` details.
+
+## Background Tasks
+
+Sessions running sub-agents show a count of active background tasks, so you can see at a glance how much work is in progress.
+
+## Session Details
+
+Click any session to expand its detail view:
+
+- **Checkpoints** — milestone summaries of work completed
+- **Recent tool output** — latest commands and results
+- **References** — linked PRs, issues, and commits
+- **Conversation history** — full turn-by-turn dialogue
+
+## Views
+
+### Tile View
+
+A compact card grid showing session state, summary, branch, MCP servers, and quick actions. Great for monitoring many sessions at once.
+
+### List View
+
+Detailed expandable rows with more metadata visible at a glance. Better for drilling into individual sessions.
+
+## Theming
+
+- **9 color palettes** — choose your preferred accent colors
+- **Light and dark mode** — toggle with one click
+- **Persistent preferences** — your choices are saved across sessions
+
+## Session Filtering
+
+Filter sessions by name, repository, branch, MCP server, or directory using the search bar at the top of the dashboard.
+
+## Tabs
+
+| Tab | Shows |
+|:----|:------|
+| **Active** | Currently running sessions with live state |
+| **Previous** | Completed sessions from session history |
+| **Timeline** | Chronological view of session activity |
+| **Files** | Most-edited files across all sessions |
+
+## Settings Menu
+
+The ☰ hamburger menu in the header provides quick access to:
+
+- Autostart-on-login toggle
+- Remote sync configuration
+- Server information

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,50 @@
+---
+title: Home
+layout: home
+nav_order: 1
+---
+
+# Copilot Session Dashboard
+
+[![GitHub release](https://img.shields.io/github/v/release/JeffSteinbok/ghcpCliDashboard)](https://github.com/JeffSteinbok/ghcpCliDashboard/releases)
+[![PyPI version](https://img.shields.io/pypi/v/ghcp-cli-dashboard.svg)](https://pypi.org/project/ghcp-cli-dashboard/)
+[![CI](https://github.com/JeffSteinbok/ghcpCliDashboard/actions/workflows/ci.yml/badge.svg)](https://github.com/JeffSteinbok/ghcpCliDashboard/actions/workflows/ci.yml)
+
+A local web dashboard that monitors all your **GitHub Copilot CLI** and **Claude Code** sessions in real-time. Designed for power users running multiple AI coding sessions simultaneously.
+{: .fs-6 .fw-300 }
+
+[Get Started]({{ site.baseurl }}/installation){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
+[View on GitHub](https://github.com/JeffSteinbok/ghcpCliDashboard){: .btn .fs-5 .mb-4 .mb-md-0 }
+
+---
+
+![Dashboard Screenshot](https://raw.githubusercontent.com/JeffSteinbok/ghcpCliDashboard/main/screenshot.png)
+
+## Quick Start
+
+```bash
+pip install ghcp-cli-dashboard
+copilot-dashboard start
+```
+
+Open **[http://localhost:5111](http://localhost:5111)** in your browser — that's it!
+
+{: .tip }
+> The dashboard works out of the box by reading `events.jsonl` files from your Copilot session directories. For richer session history (summaries, checkpoints), enable the **SESSION_STORE** experimental feature: add `"experimental": true` to `~/.copilot/config.json` and start a new Copilot session.
+
+## What You'll See
+
+| State | Indicator | Meaning |
+|:------|:----------|:--------|
+| **Working / Thinking** | 🟢 Green | Session is actively running tools or reasoning |
+| **Waiting** | 🟡 Yellow | Session needs your input (question or permission pending) |
+| **Idle** | 🔵 Blue | Session is done and ready for your next task |
+
+## Highlights
+
+- **Multi-session monitoring** — see all your Copilot and Claude Code sessions at a glance
+- **Desktop notifications** — get alerts when sessions change state
+- **One-click focus** — bring any session's terminal to the foreground
+- **Cross-machine sync** — see sessions from all your machines via OneDrive or cloud folders
+- **9 color palettes** with light and dark mode
+- **Tile & list views** — compact cards or detailed expandable rows

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,71 @@
+---
+title: Installation
+layout: default
+nav_order: 2
+---
+
+# Installation
+{: .no_toc }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+## From PyPI (Recommended)
+
+The simplest way to install:
+
+```bash
+pip install ghcp-cli-dashboard
+```
+
+This installs the `copilot-dashboard` command and all required dependencies.
+
+## From Source
+
+```bash
+# Clone the repo
+git clone https://github.com/JeffSteinbok/ghcpCliDashboard.git
+cd ghcpCliDashboard
+
+# Install in editable mode
+pip install -e .
+```
+
+## Dependencies
+
+These are installed automatically — no manual setup needed:
+
+| Package | Purpose |
+|:--------|:--------|
+| `fastapi` | Web framework with auto-generated OpenAPI docs |
+| `uvicorn` | ASGI server |
+| `pywin32` | Window focus and process detection (Windows-only) |
+
+## Prerequisites
+
+- **Python 3.10+**
+- **GitHub Copilot CLI** — the dashboard reads Copilot's session data from `~/.copilot/`
+- **Windows** — currently optimized for Windows (uses `pywin32` for window management)
+
+## Upgrading
+
+```bash
+# Upgrade via pip
+pip install --upgrade ghcp-cli-dashboard
+
+# Or use the built-in upgrade command (restarts automatically if running)
+copilot-dashboard upgrade
+```
+
+## Verifying Installation
+
+```bash
+copilot-dashboard --help
+```
+
+You should see the available commands: `start`, `stop`, `status`, `upgrade`, `autostart`, and `autostart-remove`.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,80 @@
+---
+title: Usage
+layout: default
+nav_order: 3
+---
+
+# Usage
+{: .no_toc }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+## Starting the Dashboard
+
+```bash
+# Start in the foreground
+copilot-dashboard start
+
+# Start in the background (detached)
+copilot-dashboard start --background
+
+# Start on a custom port (default: 5111)
+copilot-dashboard start --port 8080
+```
+
+Then open **[http://localhost:5111](http://localhost:5111)** (or your custom port) in your browser.
+
+## Managing the Server
+
+```bash
+# Check if the dashboard is running
+copilot-dashboard status
+
+# Stop a running dashboard
+copilot-dashboard stop
+```
+
+## Upgrading
+
+```bash
+# Upgrade to the latest version (restarts automatically if running)
+copilot-dashboard upgrade
+```
+
+This stops the server, upgrades the package via pip, and restarts it.
+
+## Autostart at Login
+
+{: .note }
+> Autostart is currently a Windows-only feature.
+
+```bash
+# Enable autostart at login
+copilot-dashboard autostart
+
+# Autostart with a custom port
+copilot-dashboard autostart --port 8080
+
+# Remove the autostart entry
+copilot-dashboard autostart-remove
+```
+
+## Command Reference
+
+| Command | Description |
+|:--------|:------------|
+| `copilot-dashboard start` | Start the dashboard server |
+| `copilot-dashboard start --background` | Start detached in the background |
+| `copilot-dashboard start --port PORT` | Start on a custom port |
+| `copilot-dashboard stop` | Stop the running dashboard |
+| `copilot-dashboard status` | Check server status |
+| `copilot-dashboard upgrade` | Upgrade and restart |
+| `copilot-dashboard autostart` | Enable Windows login startup |
+| `copilot-dashboard autostart --port PORT` | Autostart with custom port |
+| `copilot-dashboard autostart-remove` | Remove login startup |


### PR DESCRIPTION
- Configure Jekyll to build from docs/ directory
- Add pages: home, installation, usage, features, configuration, API reference, development, contributing
- Use Just the Docs remote theme with dark color scheme
- Link to interactive Swagger Editor for OpenAPI spec
- Update workflow source path to docs/

## Summary

<!-- Briefly describe what this PR does and why. -->

## Changes

<!-- List the key changes made. -->

- 

## Testing

<!-- Describe how you tested your changes. -->

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] My branch is based on `main` and is up to date
- [ ] CI checks pass (lint, type check)
- [ ] I have added or updated documentation where relevant
