### PR TITLE
Fix resumed session detection on Windows

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -97,8 +97,8 @@ MAX_UNIX_PARENT_DEPTH = 5
 MAX_DIAGNOSTICS_CHAIN = 12
 """Max depth for the diagnostics ancestry chain logged during focus."""
 
-PROCESS_MATCH_TOLERANCE = 10.0
-"""Max seconds between process creation and session.start to count as a match."""
+PROCESS_MATCH_TOLERANCE = 30.0
+"""Max seconds between process creation and session lifecycle events to count as a match."""
 
 # ── Terminal / IDE process names ──────────────────────────────────────────────
 # Used when walking the process tree to identify which ancestor owns the

--- a/src/process_tracker.py
+++ b/src/process_tracker.py
@@ -246,8 +246,11 @@ def _parse_iso_timestamp(ts_str):
 def _match_process_to_session(creation_date_str):
     """Match a copilot.exe process (without --resume) to a session by creation time.
 
-    Compares the process creation time to session.start timestamps in events.jsonl
-    files. Returns the session ID with the closest match within a 10-second window.
+    Compares the process creation time to the session lifecycle timestamps found
+    in events.jsonl. This includes both ``session.start`` and ``session.resume``
+    because resumed sessions may no longer expose ``--resume <id>`` in the live
+    process command line. Returns the session ID with the closest match within
+    the configured tolerance window.
     """
     try:
         proc_time = _parse_iso_timestamp(creation_date_str)
@@ -265,21 +268,29 @@ def _match_process_to_session(creation_date_str):
         if not os.path.exists(events_file):
             continue
         try:
+            lifecycle_timestamps = []
             with open(events_file, encoding="utf-8", errors="replace") as f:
-                first_line = f.readline().strip()
-            if not first_line:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        evt = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    if evt.get("type") not in ("session.start", "session.resume"):
+                        continue
+                    ts = evt.get("timestamp", "")
+                    if ts:
+                        lifecycle_timestamps.append(ts)
+            if not lifecycle_timestamps:
                 continue
-            evt = json.loads(first_line)
-            if evt.get("type") not in ("session.start", "session.resume"):
-                continue
-            ts = evt.get("timestamp", "")
-            if not ts:
-                continue
-            evt_time = _parse_iso_timestamp(ts)
-            delta = abs((proc_time - evt_time).total_seconds())
-            if delta < best_delta:
-                best_delta = delta
-                best_sid = sid
+            for ts in lifecycle_timestamps:
+                evt_time = _parse_iso_timestamp(ts)
+                delta = abs((proc_time - evt_time).total_seconds())
+                if delta < best_delta:
+                    best_delta = delta
+                    best_sid = sid
         except Exception as e:
             logger.debug("Error matching session %s: %s", sid, e)
             continue

--- a/src/process_tracker.py
+++ b/src/process_tracker.py
@@ -288,7 +288,7 @@ def _match_process_to_session(creation_date_str):
             for ts in lifecycle_timestamps:
                 evt_time = _parse_iso_timestamp(ts)
                 delta = abs((proc_time - evt_time).total_seconds())
-                if delta < best_delta:
+                if delta <= best_delta:
                     best_delta = delta
                     best_sid = sid
         except Exception as e:

--- a/tests/test_process_tracker.py
+++ b/tests/test_process_tracker.py
@@ -233,6 +233,13 @@ class TestMatchProcessToSession:
         event = {"type": "session.start", "timestamp": timestamp, "data": {}}
         (session_dir / "events.jsonl").write_text(json.dumps(event) + "\n")
 
+    def _write_lifecycle_events(self, tmp_path, session_id, events):
+        session_dir = tmp_path / session_id
+        session_dir.mkdir(parents=True, exist_ok=True)
+        with open(session_dir / "events.jsonl", "w", encoding="utf-8") as f:
+            for event in events:
+                f.write(json.dumps(event) + "\n")
+
     def test_matches_within_tolerance(self, tmp_path):
         ts = datetime.now(UTC)
         self._write_session_start(tmp_path, "sess-match", ts.isoformat())
@@ -245,11 +252,27 @@ class TestMatchProcessToSession:
     def test_no_match_beyond_tolerance(self, tmp_path):
         ts = datetime.now(UTC)
         self._write_session_start(tmp_path, "sess-far", ts.isoformat())
-        # Process created 30 seconds away — beyond 10s window
-        proc_ts = (ts - timedelta(seconds=30)).isoformat()
+        # Process created 31 seconds away — beyond the tolerance window
+        proc_ts = (ts - timedelta(seconds=31)).isoformat()
         with patch("src.process_tracker.EVENTS_DIR", str(tmp_path)):
             result = _match_process_to_session(proc_ts)
         assert result is None
+
+    def test_matches_resume_event_not_just_first_line(self, tmp_path):
+        start_ts = datetime.now(UTC)
+        resume_ts = start_ts + timedelta(hours=1)
+        self._write_lifecycle_events(
+            tmp_path,
+            "sess-resume",
+            [
+                {"type": "session.start", "timestamp": start_ts.isoformat(), "data": {}},
+                {"type": "session.resume", "timestamp": resume_ts.isoformat(), "data": {}},
+            ],
+        )
+        proc_ts = (resume_ts - timedelta(seconds=12)).isoformat()
+        with patch("src.process_tracker.EVENTS_DIR", str(tmp_path)):
+            result = _match_process_to_session(proc_ts)
+        assert result == "sess-resume"
 
     def test_invalid_creation_date_returns_none(self, tmp_path):
         with patch("src.process_tracker.EVENTS_DIR", str(tmp_path)):


### PR DESCRIPTION
## Summary

Match resumed Copilot sessions against all session lifecycle timestamps instead of only the first events.jsonl entry, and widen the process match tolerance to handle delayed session.resume events.

Fixes #40 *

> The fix handles:
>
> - resumed sessions that lost --resume in the live command line
> - resumed sessions where session.resume happens shortly after process start
>
> It does not handle arbitrarily late manual /resume.

## Changes

 - Updated `src/process_tracker.py` so `_match_process_to_session()` scans all lifecycle events in `events.jsonl` instead of only the first line
 - Included both `session.start` and `session.resume` events in the timestamp matching logic
 - Preserved the existing “closest timestamp wins” behavior, but made it work for resumed sessions as well as newly started sessions
 - Increased `PROCESS_MATCH_TOLERANCE` in `src/constants.py` from `10.0` to `30.0` to handle cases where the resumed process starts slightly before the `session.resume` event is written
 - Added a regression test in `tests/test_process_tracker.py` covering a resumed session whose process should match the later `session.resume` event rather than the original `session.start`


## Testing

Ran targeted validation for the affected area:
 
 - `python -m pytest tests\\test_process_tracker.py -v --tb=short`
 - `python -m ruff check src\\constants.py src\\process_tracker.py`
 - `python -m mypy src`

Add a regression test for resumed sessions that no longer expose --resume in the live process command line.

I have also run the patch locally to verify.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My branch is based on `main` and is up to date
- [ ] CI checks pass (lint, type check)
- [x] I have added or updated documentation where relevant

 ## Notes
 
I also observed unrelated pre-existing Ruff warnings in other test files, so lint validation here was scoped to the changed 
production files.
