### PR TITLE
Security + hygiene round + rebrand to AI CLI Agent Dashboard (v0.10.0)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,41 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      python-dev:
+        dependency-type: "development"
+      python-runtime:
+        dependency-type: "production"
+    labels:
+      - "dependencies"
+      - "python"
+
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      npm-dev:
+        dependency-type: "development"
+      npm-runtime:
+        dependency-type: "production"
+    labels:
+      - "dependencies"
+      - "javascript"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/.github/workflows/_build-frontend.yml
+++ b/.github/workflows/_build-frontend.yml
@@ -19,10 +19,10 @@ jobs:
         working-directory: frontend
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Set up Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: '22'
           cache: 'npm'
@@ -47,7 +47,7 @@ jobs:
         run: npm run build
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: frontend-dist
           path: src/static/dist/

--- a/.github/workflows/_lint-python.yml
+++ b/.github/workflows/_lint-python.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.13'
 

--- a/.github/workflows/_test-python.yml
+++ b/.github/workflows/_test-python.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.13'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,16 +25,16 @@ jobs:
     needs: [lint, test, frontend]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Download frontend build
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
         with:
           name: frontend-dist
           path: src/static/dist/
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.13'
 
@@ -54,13 +54,13 @@ jobs:
         run: twine check dist/*
 
       - name: Upload wheel
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: pip-package
           path: dist/
 
       - name: Upload OpenAPI spec
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: openapi-spec
           path: docs/openapi.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - explore-typescript
   pull_request:
     branches:
       - main

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,48 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly run, Mondays at 06:00 UTC
+    - cron: "0 6 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: python
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          queries: security-and-quality
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,16 +33,16 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@03e4368ac7daa2bd82b3e85262f3bf87ee112f57 # v3
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
           queries: security-and-quality
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@03e4368ac7daa2bd82b3e85262f3bf87ee112f57 # v3
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -27,16 +27,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
       - name: Build with Jekyll
-        uses: actions/jekyll-build-pages@v1
+        uses: actions/jekyll-build-pages@44a6e6beabd48582f863aeeb6cb2151cc1716697 # v1
         with:
           source: ./docs
           destination: ./_site
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
 
   # Deployment job
   deploy:
@@ -48,4 +48,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -19,16 +19,16 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Download frontend build
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
         with:
           name: frontend-dist
           path: src/static/dist/
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.13'
 
@@ -44,6 +44,6 @@ jobs:
         run: twine check dist/*
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,13 +49,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
           token: ${{ secrets.PAT_TOKEN }}
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.13'
 
@@ -130,7 +130,7 @@ jobs:
 
     steps:
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           tag_name: v${{ needs.bump-version.outputs.new_version }}
           name: Release v${{ needs.bump-version.outputs.new_version }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to Copilot Session Dashboard
+# Contributing to AI CLI Agent Dashboard
 
 Thank you for your interest in contributing! This document explains how to get involved.
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Open **http://localhost:5111** in your browser.
 
 ## Features
 
-### ✨ New in v0.7
+### ✨ Recent additions
 
 - **Claude Code support** — automatically discovers Claude Code sessions from `~/.claude/projects/`. Active Claude sessions appear alongside Copilot sessions with a `✦ Claude` badge.
 - **Cross-machine sync** — see active sessions from all your machines in one dashboard, powered by OneDrive or any cloud-synced folder. See [Cross-Machine Sync](#cross-machine-sync) for details.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Copilot Session Dashboard
+# AI CLI Agent Dashboard
 [![GitHub](https://img.shields.io/badge/GitHub-ghcpCliDashboard-blue?logo=github)](https://github.com/JeffSteinbok/ghcpCliDashboard)
 [![GitHub release](https://img.shields.io/github/v/release/JeffSteinbok/ghcpCliDashboard)](https://github.com/JeffSteinbok/ghcpCliDashboard/releases)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,61 @@
+# Security Policy
+
+## Supported Versions
+
+`ghcp-cli-dashboard` follows a rolling-release model. Only the latest
+published version on PyPI receives security fixes.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| latest  | :white_check_mark: |
+| older   | :x:                |
+
+Always upgrade to the latest version (`pip install -U ghcp-cli-dashboard`)
+before reporting a vulnerability.
+
+## Reporting a Vulnerability
+
+**Please do NOT open a public GitHub issue for security vulnerabilities.**
+
+Report vulnerabilities privately via GitHub Security Advisories:
+
+1. Go to <https://github.com/JeffSteinbok/ghcpCliDashboard/security/advisories/new>
+2. Provide:
+   - A clear description of the vulnerability and the affected
+     component (CLI command, API endpoint, frontend route, etc.)
+   - Steps to reproduce, including version numbers and OS
+   - The impact you've assessed (e.g. local-network exposure, RCE,
+     data exposure)
+   - Any suggested mitigation, if known
+
+You should receive an acknowledgement within **5 business days**. We aim to
+provide a fix or detailed mitigation plan within **30 days** for confirmed
+vulnerabilities, prioritized by severity.
+
+## Scope
+
+`ghcp-cli-dashboard` is a **local-first** tool. The default deployment
+binds to `127.0.0.1` only and requires a per-instance random API token
+for every `/api/*` request. Findings particularly in scope include:
+
+- Authentication / authorization bypass on `/api/*` endpoints
+- Code injection (RCE) via session data, sync folder, or update flow
+- Path traversal or unauthorized filesystem access
+- Cross-site scripting (XSS) in any rendered HTML or JSON
+- DNS-rebinding or `Host`-header attacks against the local server
+- Supply-chain weaknesses in build, release, or distribution
+
+Findings explicitly **out of scope**:
+
+- Issues that require an attacker to already have local code execution
+  on the same machine as the user
+- Denial-of-service via resource exhaustion (the dashboard is a local
+  tool with no SLA)
+- Theoretical attacks against third-party dependencies without a
+  demonstrated exploit path through this codebase
+
+## Responsible Disclosure
+
+We follow coordinated disclosure. Please give us a reasonable window
+(typically 90 days) to ship a fix before publishing details. We will
+credit reporters in release notes unless anonymity is requested.

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,4 +1,4 @@
-title: Copilot Session Dashboard
+title: AI CLI Agent Dashboard
 description: A local web dashboard that monitors all your GitHub Copilot CLI and Claude Code sessions in real-time.
 
 remote_theme: just-the-docs/just-the-docs@v0.10.1

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -107,7 +107,7 @@ The sync folder is auto-detected in this priority order:
   "grouping": {
     "skip_dirs": ["jeffs", "projects"],
     "mappings": {
-      "ghcpCliDashboard": "Copilot Dashboard",
+      "ghcpCliDashboard": "AI CLI Agent Dashboard",
       "review": "Code Reviews",
       "docs": "Documentation"
     }

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ layout: home
 nav_order: 1
 ---
 
-# Copilot Session Dashboard
+# AI CLI Agent Dashboard
 
 [![GitHub release](https://img.shields.io/github/v/release/JeffSteinbok/ghcpCliDashboard)](https://github.com/JeffSteinbok/ghcpCliDashboard/releases)
 [![PyPI version](https://img.shields.io/pypi/v/ghcp-cli-dashboard.svg)](https://pypi.org/project/ghcp-cli-dashboard/)

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1,8 +1,8 @@
 {
   "openapi": "3.1.0",
   "info": {
-    "title": "Copilot Dashboard",
-    "description": "Monitor all your GitHub Copilot CLI sessions in real-time.",
+    "title": "AI CLI Agent Dashboard",
+    "description": "Monitor all your GitHub Copilot CLI and Claude Code sessions in real-time.",
     "version": "0.9.2"
   },
   "paths": {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Copilot Session Dashboard</title>
+    <title>AI CLI Agent Dashboard</title>
     <link rel="icon" href="/favicon.png" />
     <link rel="manifest" href="/manifest.json" />
   </head>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -132,6 +132,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -524,6 +525,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -564,6 +566,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1062,9 +1065,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1143,9 +1146,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1792,8 +1795,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -1878,6 +1880,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1888,6 +1891,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -1927,6 +1931,7 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -2294,6 +2299,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2344,7 +2350,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2445,9 +2450,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
-      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2477,6 +2482,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2713,8 +2719,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.302",
@@ -2814,6 +2819,7 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2926,9 +2932,9 @@
       "license": "MIT"
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3153,9 +3159,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -3433,6 +3439,7 @@
       "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.31",
         "@asamuzakjp/dom-selector": "^6.8.1",
@@ -3590,7 +3597,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -3674,9 +3680,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -3828,11 +3834,12 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3841,9 +3848,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -3861,7 +3868,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -3885,7 +3892,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -3901,7 +3907,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -3924,6 +3929,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -3936,6 +3942,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -3949,8 +3956,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -4298,6 +4304,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4307,9 +4314,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.22.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
-      "integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.26.0.tgz",
+      "integrity": "sha512-3O9Tf67pGhgOv9jM35AbhkXAKi13f3oy3aE4CSgr+TckGeY+/iu97ZXN+J7DpHPzLbVApFd1IFhcnBjREYXYcg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4358,11 +4365,12 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
+      "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -4438,6 +4446,7 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -4644,6 +4653,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -5,7 +5,8 @@
  * All responses are typed to match the Pydantic models (src/schemas.py).
  *
  * All /api/* requests include a per-instance auth token injected by the
- * server into window.__DASHBOARD_TOKEN__ at page load.
+ * server into window.__DASHBOARD_TOKEN__ at page load, sent as
+ * `Authorization: Bearer <token>` on every request.
  */
 
 import type {
@@ -24,22 +25,21 @@ function getToken(): string {
   return window.__DASHBOARD_TOKEN__ ?? "";
 }
 
-/** Append the auth token as a query parameter. */
-function withToken(url: string): string {
-  const sep = url.includes("?") ? "&" : "?";
-  return `${url}${sep}token=${encodeURIComponent(getToken())}`;
+/** Build an Authorization header for every API request. */
+function authHeader(): Record<string, string> {
+  return { Authorization: `Bearer ${getToken()}` };
 }
 
 /** Generic GET helper — throws on non-2xx responses. */
 async function get<T>(url: string): Promise<T> {
-  const resp = await fetch(withToken(url));
+  const resp = await fetch(url, { headers: authHeader() });
   if (!resp.ok) throw new Error(`${resp.status} ${resp.statusText}`);
   return resp.json() as Promise<T>;
 }
 
 /** Generic POST helper — throws on non-2xx responses. */
 async function post<T>(url: string): Promise<T> {
-  const resp = await fetch(withToken(url), { method: "POST" });
+  const resp = await fetch(url, { method: "POST", headers: authHeader() });
   if (!resp.ok) throw new Error(`${resp.status} ${resp.statusText}`);
   return resp.json() as Promise<T>;
 }
@@ -48,7 +48,7 @@ async function post<T>(url: string): Promise<T> {
 async function put<T>(url: string, body: unknown): Promise<T> {
   const resp = await fetch(url, {
     method: "PUT",
-    headers: { "Content-Type": "application/json" },
+    headers: { ...authHeader(), "Content-Type": "application/json" },
     body: JSON.stringify(body),
   });
   if (!resp.ok) throw new Error(`${resp.status} ${resp.statusText}`);
@@ -118,7 +118,7 @@ export function fetchServerInfo(): Promise<ServerInfo> {
  */
 export async function triggerUpdate(): Promise<void> {
   try {
-    await fetch(withToken("/api/update"), { method: "POST" });
+    await fetch("/api/update", { method: "POST", headers: authHeader() });
   } catch {
     // Server dies mid-response during self-update — this is expected
   }

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,5 +1,5 @@
 /**
- * Typed API client for the Copilot Dashboard backend.
+ * Typed API client for the AI CLI Agent Dashboard backend.
  *
  * Each function maps 1:1 to a FastAPI route in dashboard_api.py.
  * All responses are typed to match the Pydantic models (src/schemas.py).

--- a/frontend/src/components/HamburgerMenu.tsx
+++ b/frontend/src/components/HamburgerMenu.tsx
@@ -139,7 +139,7 @@ export default function HamburgerMenu() {
           }}
         >
           <div className="modal">
-            <h2>🤖 Copilot Dashboard</h2>
+            <h2>🤖 AI CLI Agent Dashboard</h2>
             <p>
               A local dashboard that monitors all your GitHub Copilot CLI and
               Claude Code sessions in real-time.

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -46,7 +46,7 @@ export default function Header({
         }}
         alt=""
       />
-      <h1>Copilot Dashboard</h1>
+      <h1>AI CLI Agent Dashboard</h1>
 
       {/* Waiting badge — only shown when sessions are waiting for input */}
       {waitingCount > 0 && (
@@ -55,18 +55,7 @@ export default function Header({
         </span>
       )}
 
-      <div className="header-credits">
-        Created by{" "}
-        <strong>
-          <a
-            href="https://github.com/JeffSteinbok"
-            target="_blank"
-            rel="noreferrer"
-          >
-            Jeff Steinbok
-          </a>
-        </strong>
-        &nbsp;&bull;&nbsp;
+      <div className="header-version">
         <span
           id="version-display"
           data-tip={

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -1,5 +1,5 @@
 /**
- * Centralised constants for the Copilot Dashboard frontend.
+ * Centralised constants for the AI CLI Agent Dashboard frontend.
  *
  * All magic numbers, polling intervals, localStorage keys, and
  * lookup tables live here so they are easy to find, tune, and test.

--- a/frontend/src/hooks/useNotifications.tsx
+++ b/frontend/src/hooks/useNotifications.tsx
@@ -14,7 +14,7 @@ export function useNotifications() {
       const next = !notificationsEnabled;
       dispatch({ type: "SET_NOTIFICATIONS", enabled: next });
       if (next) {
-        try { new Notification("Copilot Dashboard", { body: "Notifications enabled!" }); }
+        try { new Notification("AI CLI Agent Dashboard", { body: "Notifications enabled!" }); }
         catch { /* permission may have been revoked */ }
       }
       return;
@@ -24,7 +24,7 @@ export function useNotifications() {
       const granted = p === "granted";
       dispatch({ type: "SET_NOTIFICATIONS", enabled: granted });
       if (granted) {
-        try { new Notification("Copilot Dashboard", { body: "Notifications enabled!" }); }
+        try { new Notification("AI CLI Agent Dashboard", { body: "Notifications enabled!" }); }
         catch { /* permission may have been revoked */ }
       }
     });

--- a/frontend/src/test/App.test.tsx
+++ b/frontend/src/test/App.test.tsx
@@ -5,7 +5,7 @@ import App from "../components/App";
 describe("App", () => {
   it("renders the dashboard header", () => {
     render(<App />);
-    expect(screen.getByText("Copilot Dashboard")).toBeInTheDocument();
+    expect(screen.getByText("AI CLI Agent Dashboard")).toBeInTheDocument();
   });
 
   it("shows the Active tab by default", () => {

--- a/frontend/src/test/api.test.ts
+++ b/frontend/src/test/api.test.ts
@@ -35,34 +35,34 @@ function jsonResponse(data: unknown, status = 200) {
 
 describe("API client", () => {
   // Token is set in setup.ts as "test-token"
-  const T = "?token=test-token";
+  const AUTH = { headers: { Authorization: "Bearer test-token" } };
 
   describe("GET endpoints", () => {
     it("fetchSessions calls /api/sessions", async () => {
       mockFetch.mockReturnValue(jsonResponse([{ id: "abc" }]));
       const result = await fetchSessions();
-      expect(mockFetch).toHaveBeenCalledWith(`/api/sessions${T}`);
+      expect(mockFetch).toHaveBeenCalledWith("/api/sessions", AUTH);
       expect(result).toEqual([{ id: "abc" }]);
     });
 
     it("fetchProcesses calls /api/processes", async () => {
       mockFetch.mockReturnValue(jsonResponse({ abc: { pid: 123 } }));
       const result = await fetchProcesses();
-      expect(mockFetch).toHaveBeenCalledWith(`/api/processes${T}`);
+      expect(mockFetch).toHaveBeenCalledWith("/api/processes", AUTH);
       expect(result).toEqual({ abc: { pid: 123 } });
     });
 
     it("fetchSessionDetail calls /api/session/:id", async () => {
       mockFetch.mockReturnValue(jsonResponse({ checkpoints: [] }));
       const result = await fetchSessionDetail("test-id");
-      expect(mockFetch).toHaveBeenCalledWith(`/api/session/test-id${T}`);
+      expect(mockFetch).toHaveBeenCalledWith("/api/session/test-id", AUTH);
       expect(result).toEqual({ checkpoints: [] });
     });
 
     it("fetchFiles calls /api/files", async () => {
       mockFetch.mockReturnValue(jsonResponse([]));
       await fetchFiles();
-      expect(mockFetch).toHaveBeenCalledWith(`/api/files${T}`);
+      expect(mockFetch).toHaveBeenCalledWith("/api/files", AUTH);
     });
 
     it("fetchVersion calls /api/version", async () => {
@@ -82,15 +82,18 @@ describe("API client", () => {
     it("focusSession calls /api/focus/:id via POST", async () => {
       mockFetch.mockReturnValue(jsonResponse({ success: true, message: "ok" }));
       await focusSession("sid-1");
-      expect(mockFetch).toHaveBeenCalledWith(`/api/focus/sid-1${T}`, { method: "POST" });
+      expect(mockFetch).toHaveBeenCalledWith("/api/focus/sid-1", {
+        method: "POST",
+        headers: { Authorization: "Bearer test-token" },
+      });
     });
 
     it("killSession URL-encodes the session ID", async () => {
       mockFetch.mockReturnValue(jsonResponse({ success: true, message: "killed" }));
       await killSession("path/with/slashes");
       expect(mockFetch).toHaveBeenCalledWith(
-        `/api/kill/path%2Fwith%2Fslashes${T}`,
-        { method: "POST" },
+        "/api/kill/path%2Fwith%2Fslashes",
+        { method: "POST", headers: { Authorization: "Bearer test-token" } },
       );
     });
 

--- a/frontend/src/test/hooks.test.ts
+++ b/frontend/src/test/hooks.test.ts
@@ -153,7 +153,9 @@ describe("useVersion", () => {
       await vi.advanceTimersByTimeAsync(0);
     });
 
-    expect(mockFetch).toHaveBeenCalledWith("/api/version?token=test-token");
+    expect(mockFetch).toHaveBeenCalledWith("/api/version", {
+      headers: { Authorization: "Bearer test-token" },
+    });
     expect(result.current.versionInfo.update_available).toBe(true);
     expect(result.current.versionInfo.latest).toBe("2.0.0");
   });
@@ -323,8 +325,12 @@ describe("useSessions", () => {
       await vi.advanceTimersByTimeAsync(0);
     });
 
-    expect(mockFetch).toHaveBeenCalledWith("/api/sessions?token=test-token");
-    expect(mockFetch).toHaveBeenCalledWith("/api/processes?token=test-token");
+    expect(mockFetch).toHaveBeenCalledWith("/api/sessions", {
+      headers: { Authorization: "Bearer test-token" },
+    });
+    expect(mockFetch).toHaveBeenCalledWith("/api/processes", {
+      headers: { Authorization: "Bearer test-token" },
+    });
   });
 
   it("handles fetch failure gracefully", async () => {

--- a/frontend/src/themes.css
+++ b/frontend/src/themes.css
@@ -198,8 +198,8 @@ a:hover { text-decoration: underline; }
 }
 .header .logo { font-size: 22px; }
 .header h1 { font-size: 22px; font-weight: 600; white-space: nowrap; }
-.header-credits { font-size: 13px; color: var(--text2); white-space: nowrap; }
-.header-credits a { color: var(--accent); cursor: pointer; }
+.header-version { font-size: 13px; color: var(--text2); white-space: nowrap; }
+.header-version a { color: var(--accent); cursor: pointer; }
 .header-right { margin-left: auto; display: flex; align-items: center; gap: 12px; }
 .theme-controls { display: flex; align-items: center; gap: 8px; }
 .theme-btn, .palette-select {

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
 -r requirements.txt
-pytest
-pytest-cov
-httpx
+pytest>=8,<9
+pytest-cov>=5,<7
+httpx>=0.27,<1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-fastapi
-uvicorn
-platformdirs
-pywinauto; sys_platform == "win32"
+fastapi>=0.115,<1
+uvicorn>=0.30,<1
+platformdirs>=4,<5
+pywinauto>=0.6,<1; sys_platform == "win32"

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,6 @@ setup(
     include_package_data=True,
     install_requires=requirements + [
         'pywin32; sys_platform == "win32"',
-        'pywinauto; sys_platform == "win32"',
     ],
     python_requires=">=3.11",
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-"""Setup script for Copilot Session Dashboard."""
+"""Setup script for AI CLI Agent Dashboard."""
 
 from pathlib import Path
 
@@ -23,11 +23,11 @@ with open(readme_file, encoding="utf-8") as f:
 setup(
     name="ghcp-cli-dashboard",
     version=version["__version__"],
-    description="A local web dashboard that monitors all your GitHub Copilot CLI sessions in real-time",
+    description="A local web dashboard that monitors all your GitHub Copilot CLI and Claude Code sessions in real-time",
     long_description=long_description,
     long_description_content_type="text/markdown",
     author="Jeff Steinbok",
-    url="https://github.com/JeffSteinbok/ghcpCliSessionDashboard",
+    url="https://github.com/JeffSteinbok/ghcpCliDashboard",
     license="MIT",
     packages=find_packages(exclude=["tests", "tests.*"]),
     include_package_data=True,

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,4 @@
-"""Copilot Dashboard — monitor all your GitHub Copilot CLI sessions."""
+"""AI CLI Agent Dashboard — monitor your GitHub Copilot CLI and Claude Code sessions."""
 
 from .__version__ import __repository__, __version__
 

--- a/src/__version__.py
+++ b/src/__version__.py
@@ -1,4 +1,4 @@
-"""Version information for Copilot Dashboard."""
+"""Version information for AI CLI Agent Dashboard."""
 
 __version__ = "0.9.2"
 __repository__ = "https://github.com/JeffSteinbok/ghcpCliDashboard"

--- a/src/claude_code.py
+++ b/src/claude_code.py
@@ -1,5 +1,5 @@
 """
-Claude Code session reader for the Copilot Dashboard.
+Claude Code session reader for the AI CLI Agent Dashboard.
 
 Reads session data from ~/.claude/projects/ (sessions-index.json + JSONL
 transcripts) and detects running claude processes, mapping everything to

--- a/src/claude_code.py
+++ b/src/claude_code.py
@@ -13,6 +13,8 @@ import logging
 import os
 import subprocess
 import sys
+import threading
+import time
 from collections import Counter
 from datetime import UTC, datetime
 
@@ -22,6 +24,7 @@ from .constants import (
     PARENT_LOOKUP_TIMEOUT,
     POWERSHELL_TIMEOUT,
     PS_TIMEOUT,
+    RUNNING_CACHE_TTL,
     TERMINAL_NAMES,
     UNIX_TERMINAL_SUBSTRINGS,
 )
@@ -438,14 +441,39 @@ def get_running_claude_sessions() -> dict[str, ProcessInfo]:
     """Detect running Claude Code processes and match to sessions.
 
     Returns dict: {prefixed_session_id: ProcessInfo}
+
+    Uses a TTL cache (same TTL as the Copilot path) to avoid repeatedly
+    spawning slow PowerShell `Get-CimInstance Win32_Process` queries on
+    Windows. Without this cache, /api/sessions blocks for up to 30s on
+    every cold request because the PowerShell call can take that long.
     """
-    try:
-        if sys.platform == "win32":
-            return _get_running_claude_windows()
-        return _get_running_claude_unix()
-    except Exception as e:
-        logger.warning("Error scanning Claude processes: %s", e)
-        return {}
+    global _running_claude_cache_time, _running_claude_cache_data
+    with _running_claude_lock:
+        now = time.monotonic()
+        if (
+            now - _running_claude_cache_time < RUNNING_CACHE_TTL
+            and _running_claude_cache_data is not None
+        ):
+            return _running_claude_cache_data
+        try:
+            if sys.platform == "win32":
+                data = _get_running_claude_windows()
+            else:
+                data = _get_running_claude_unix()
+        except Exception as e:
+            logger.warning("Error scanning Claude processes: %s", e)
+            data = {}
+        _running_claude_cache_data = data
+        _running_claude_cache_time = time.monotonic()
+        return data
+
+
+# Module-global TTL cache for get_running_claude_sessions() — mirrors the
+# Copilot path's _running_cache. Without this, every /api/sessions call
+# blocks for several seconds on the PowerShell process-scan subprocess.
+_running_claude_cache_data: dict[str, ProcessInfo] | None = None
+_running_claude_cache_time: float = 0.0
+_running_claude_lock = threading.Lock()
 
 
 def _get_running_claude_windows() -> dict[str, ProcessInfo]:

--- a/src/constants.py
+++ b/src/constants.py
@@ -1,5 +1,5 @@
 """
-Centralised constants for the Copilot Dashboard backend.
+Centralised constants for the AI CLI Agent Dashboard backend.
 
 All magic numbers, timeouts, file-system paths, and hardcoded lists live
 here so they are easy to find, tune, and test.

--- a/src/dashboard_api.py
+++ b/src/dashboard_api.py
@@ -1,5 +1,5 @@
 """
-Copilot Dashboard — FastAPI web application.
+AI CLI Agent Dashboard — FastAPI web application.
 
 Serves a real-time dashboard of all Copilot CLI sessions with:
   - Active vs Previous session split
@@ -86,9 +86,9 @@ DIST_DIR = os.path.join(STATIC_DIR, "dist")
 TEMPLATES_DIR = os.path.join(PKG_DIR, "templates")
 
 app = FastAPI(
-    title="Copilot Dashboard",
+    title="AI CLI Agent Dashboard",
     version=__version__,
-    description="Monitor all your GitHub Copilot CLI sessions in real-time.",
+    description="Monitor all your GitHub Copilot CLI and Claude Code sessions in real-time.",
 )
 
 # ── Security ─────────────────────────────────────────────────────────────────
@@ -929,8 +929,8 @@ def favicon():
 def manifest():
     """PWA web app manifest — enables 'Install app' in Chrome/Edge."""
     data = {
-        "name": "Copilot Dashboard",
-        "short_name": "Copilot",
+        "name": "AI CLI Agent Dashboard",
+        "short_name": "AI Agents",
         "description": "Monitor all your GitHub Copilot CLI sessions in real-time.",
         "start_url": "/",
         "scope": "/",
@@ -991,7 +991,7 @@ def index():
         return HTMLResponse(html)
     return HTMLResponse(
         f"<html><head>{token_script}</head><body>"
-        "<h1>Copilot Dashboard</h1><p>No frontend build found.</p></body></html>"
+        "<h1>AI CLI Agent Dashboard</h1><p>No frontend build found.</p></body></html>"
     )
 
 

--- a/src/dashboard_api.py
+++ b/src/dashboard_api.py
@@ -1,13 +1,12 @@
 """
 AI CLI Agent Dashboard — FastAPI web application.
 
-Serves a real-time dashboard of all Copilot CLI sessions with:
+Serves a real-time dashboard of all Copilot CLI and Claude Code sessions with:
   - Active vs Previous session split
   - Project-area grouping
   - Restart commands with copy buttons
   - Click-to-focus terminal windows
   - Light/dark mode and palette selector
-  - Auto-generated OpenAPI docs at /docs
 """
 
 import json
@@ -28,6 +27,7 @@ from datetime import UTC, datetime
 
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.middleware.trustedhost import TrustedHostMiddleware
 from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, Response
 from fastapi.staticfiles import StaticFiles
 
@@ -89,6 +89,15 @@ app = FastAPI(
     title="AI CLI Agent Dashboard",
     version=__version__,
     description="Monitor all your GitHub Copilot CLI and Claude Code sessions in real-time.",
+    # Disable interactive Swagger UI and the OpenAPI schema endpoint:
+    # the dashboard is a local tool and the schema is exported separately
+    # via scripts.export_openapi to docs/openapi.json for the Jekyll docs
+    # site. Leaving /docs and /openapi.json open would expose API surface
+    # information without authentication and complicate auth (Swagger UI
+    # has no path to add a Bearer token to its schema fetch).
+    docs_url=None,
+    redoc_url=None,
+    openapi_url=None,
 )
 
 # ── Security ─────────────────────────────────────────────────────────────────
@@ -96,24 +105,23 @@ app = FastAPI(
 # Per-instance token generated at startup; required on all /api/* requests.
 API_TOKEN: str = secrets.token_urlsafe(32)
 
+# Trusted Host: defend against DNS-rebinding attacks. The server binds to
+# 127.0.0.1, but without this middleware a malicious page (e.g. on
+# attacker.com) could DNS-rebind its hostname to 127.0.0.1, load the
+# dashboard, and exfiltrate the API token from window.__DASHBOARD_TOKEN__.
+# Restricting allowed Host headers blocks that vector.
+app.add_middleware(
+    TrustedHostMiddleware,
+    allowed_hosts=["127.0.0.1", "localhost"],
+)
+
 # CORS: only allow same-origin requests (no cross-origin API access)
 app.add_middleware(
     CORSMiddleware,
     allow_origins=[],  # no cross-origin allowed
     allow_credentials=False,
-    allow_methods=["GET", "POST"],
+    allow_methods=["GET", "POST", "PUT"],
     allow_headers=["Authorization"],
-)
-
-# Paths that are exempt from token validation
-_PUBLIC_PATH_PREFIXES = (
-    "/static",
-    "/assets",
-    "/favicon",
-    "/manifest",
-    "/sw.js",
-    "/docs",
-    "/openapi.json",
 )
 
 
@@ -724,15 +732,23 @@ def api_update(request: Request):
     """Spawn a detached subprocess to pip-upgrade the package and restart."""
     scope = request.scope
     server = scope.get("server")
-    port = str(server[1]) if server and len(server) >= 2 else "5111"
+    port_raw = server[1] if server and len(server) >= 2 else 5111
+    try:
+        port_int = int(port_raw)
+    except (TypeError, ValueError):
+        port_int = 5111
     server_pid = os.getpid()
 
+    # Use json.dumps() for all interpolated values so a future contributor
+    # cannot accidentally introduce RCE by interpolating a user-controlled
+    # string. port and server_pid are trusted (from Uvicorn + os.getpid())
+    # but defense-in-depth matters in a script-builder pattern.
     script_lines = [
         "import subprocess, sys, os, signal, time, shutil",
         "time.sleep(2)",
         # Kill the server BEFORE pip upgrade to release file locks and
         # avoid corrupting the pip cache on Windows.
-        f"pid = {server_pid}",
+        f"pid = {json.dumps(server_pid)}",
         "try:",
         "    if sys.platform == 'win32':",
         "        subprocess.run(['taskkill', '/F', '/PID', str(pid)], capture_output=True, check=False)",
@@ -751,7 +767,7 @@ def api_update(request: Request):
         "        kw['creationflags'] = subprocess.CREATE_NO_WINDOW | 0x8",
         "    else:",
         "        kw['start_new_session'] = True",
-        f"    subprocess.Popen([cmd, 'start', '--background', '--port', '{port}'], **kw)",
+        f"    subprocess.Popen([cmd, 'start', '--background', '--port', str({json.dumps(port_int)})], **kw)",
     ]
     script = "\n".join(script_lines)
 
@@ -809,7 +825,13 @@ def api_autostart_enable(request: Request):
 
     scope = request.scope
     server = scope.get("server")
-    port = str(server[1]) if server and len(server) >= 2 else "5111"
+    port_raw = server[1] if server and len(server) >= 2 else 5111
+    # Validate port as int before interpolating into a registry command line.
+    # port_raw is trusted (from Uvicorn) but defense-in-depth.
+    try:
+        port = str(int(port_raw))
+    except (TypeError, ValueError):
+        return {"success": False, "message": f"Invalid port value: {port_raw!r}"}
 
     cmd = shutil.which("copilot-dashboard")
     if cmd:

--- a/src/grouping.py
+++ b/src/grouping.py
@@ -1,4 +1,4 @@
-"""Session grouping logic for the Copilot Dashboard.
+"""Session grouping logic for the AI CLI Agent Dashboard.
 
 Derives a project/area group name from session metadata using a generic
 algorithm. Supports optional user-defined custom group mappings via

--- a/src/logging_config.py
+++ b/src/logging_config.py
@@ -1,5 +1,5 @@
 """
-Centralised logging configuration for the Copilot Dashboard.
+Centralised logging configuration for the AI CLI Agent Dashboard.
 
 Provides a single ``setup_logging()`` call that configures the root
 ``src`` logger with a :class:`~logging.handlers.RotatingFileHandler`

--- a/src/models.py
+++ b/src/models.py
@@ -1,4 +1,4 @@
-"""Typed data models for the Copilot Dashboard."""
+"""Typed data models for the AI CLI Agent Dashboard."""
 
 from __future__ import annotations
 

--- a/src/process_tracker.py
+++ b/src/process_tracker.py
@@ -12,6 +12,8 @@ import subprocess
 import sys
 import threading
 import time
+from concurrent.futures import Future, ThreadPoolExecutor
+from copy import copy
 from datetime import UTC, datetime
 
 from .constants import (
@@ -48,6 +50,15 @@ WAITING_TOOLS = frozenset({"ask_user", "ask_permission"})
 # TTL cache for get_running_sessions() — avoids repeated WMI/ps subprocess calls
 _running_cache = RunningCache()
 _running_lock = threading.Lock()
+
+# Background enrichment state for Windows window-title lookup. UIA traversal
+# is slow (often > 5s on machines with many Windows Terminal tabs) so we run
+# it asynchronously after returning the base session list, then atomically
+# swap the enriched data into the cache for the next request. Guarded by
+# _running_lock; only one enrichment job runs at a time.
+_enrichment_executor: ThreadPoolExecutor | None = None
+_enrichment_future: Future | None = None
+_ENRICHMENT_TIMEOUT_SEC = 5.0
 
 # Permanent cache for inactive session event data (mcp_servers, tool_counts,
 # context, intent). Active sessions are re-read each poll; inactive ones are
@@ -590,6 +601,65 @@ def _populate_window_titles(sessions: dict[str, ProcessInfo]):
         logger.debug("Error populating window titles: %s", e)
 
 
+def _has_windows_terminal_running(sessions: dict[str, ProcessInfo]) -> bool:
+    """Cheap check: are any of the sessions actually hosted in Windows Terminal?
+
+    UIA traversal is expensive even on no-op runs, so skip enrichment entirely
+    when no session is in a WT host.
+    """
+    for info in sessions.values():
+        if info.terminal_name.lower() in ("windowsterminal.exe", "wt.exe"):
+            return True
+    return False
+
+
+def _enrich_titles_in_background(base: dict[str, ProcessInfo]) -> None:
+    """Run UIA enrichment on a COPY and atomically swap into the cache.
+
+    Designed for the background thread spawned by `get_running_sessions()`:
+    never mutates the cache in place (other requests may be reading it),
+    builds an enriched copy, then swaps under `_running_lock`.
+    """
+    try:
+        enriched = {sid: copy(info) for sid, info in base.items()}
+        _populate_window_titles(enriched)
+        with _running_lock:
+            # Only commit if the cache hasn't been replaced by a newer scan
+            # in the meantime; otherwise our enriched data is stale.
+            if _running_cache.data is base:
+                _running_cache.data = enriched
+    except Exception as e:
+        logger.debug("Background window-title enrichment failed: %s", e)
+
+
+def _get_enrichment_executor() -> ThreadPoolExecutor:
+    """Lazily create the single-worker executor for UIA enrichment."""
+    global _enrichment_executor
+    if _enrichment_executor is None:
+        _enrichment_executor = ThreadPoolExecutor(
+            max_workers=1, thread_name_prefix="ui-enrich"
+        )
+    return _enrichment_executor
+
+
+def _maybe_spawn_enrichment(base: dict[str, ProcessInfo]) -> None:
+    """Spawn background window-title enrichment iff no job is in flight.
+
+    Caller must hold `_running_lock`. If a previous enrichment job is still
+    running (e.g. stuck on a UIA call), do nothing — avoids thread storms
+    when UIA hangs.
+    """
+    global _enrichment_future
+    if sys.platform != "win32":
+        return
+    if not _has_windows_terminal_running(base):
+        return
+    if _enrichment_future is not None and not _enrichment_future.done():
+        return  # previous job still running; don't spawn another
+    executor = _get_enrichment_executor()
+    _enrichment_future = executor.submit(_enrich_titles_in_background, base)
+
+
 def get_running_sessions() -> dict[str, ProcessInfo]:
     """
     Find running copilot processes and extract session info.
@@ -597,6 +667,13 @@ def get_running_sessions() -> dict[str, ProcessInfo]:
     Uses a TTL cache to avoid repeated expensive WMI/ps subprocess calls.
     Lock is held across the entire operation so concurrent requests wait
     for the first one rather than each spawning their own subprocess.
+
+    Window-title enrichment on Windows (via UIA) is deferred to a
+    background thread because UIA can hang for several seconds. The first
+    response after a cache expiry returns without window titles; the next
+    request hits the enriched cache. This trades a small per-call
+    `focus_session_window()` regression on the cold call for much faster
+    initial /api/sessions and /api/processes responses.
     """
     with _running_lock:
         now = time.monotonic()
@@ -607,7 +684,7 @@ def get_running_sessions() -> dict[str, ProcessInfo]:
                 sessions = _get_running_sessions_windows()
             else:
                 sessions = _get_running_sessions_unix()
-            # Enrich each session with state info
+            # Enrich each session with state info (fast — local file reads only)
             for sid, info in sessions.items():
                 ss = _get_session_state(sid)
                 info.state = ss["state"]
@@ -615,11 +692,13 @@ def get_running_sessions() -> dict[str, ProcessInfo]:
                 info.bg_tasks = ss["bg_tasks"]
                 info.bg_task_list = ss["bg_task_list"]
 
-            # On Windows, populate window_title from WT tab titles (via UIA)
-            if sys.platform == "win32":
-                _populate_window_titles(sessions)
             _running_cache.data = sessions
             _running_cache.time = time.monotonic()
+
+            # Window-title enrichment runs in background and atomically
+            # swaps the cache when done; the NEXT request gets enriched data.
+            _maybe_spawn_enrichment(sessions)
+
             return sessions
         except Exception as e:
             print(f"[process_tracker] Error scanning processes: {e}")

--- a/src/process_tracker.py
+++ b/src/process_tracker.py
@@ -636,9 +636,7 @@ def _get_enrichment_executor() -> ThreadPoolExecutor:
     """Lazily create the single-worker executor for UIA enrichment."""
     global _enrichment_executor
     if _enrichment_executor is None:
-        _enrichment_executor = ThreadPoolExecutor(
-            max_workers=1, thread_name_prefix="ui-enrich"
-        )
+        _enrichment_executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="ui-enrich")
     return _enrichment_executor
 
 

--- a/src/session_dashboard.py
+++ b/src/session_dashboard.py
@@ -1,5 +1,5 @@
 """
-Copilot Dashboard - CLI entry point.
+AI CLI Agent Dashboard - CLI entry point.
 Provides start, stop, and status subcommands.
 """
 
@@ -26,8 +26,8 @@ PKG_DIR = os.path.dirname(os.path.abspath(__file__))
 from .__version__ import __repository__, __version__  # noqa: E402
 
 BANNER = f"""\
-  Copilot Dashboard v{__version__}
-  By Jeff Steinbok — {__repository__}
+  AI CLI Agent Dashboard v{__version__}
+  {__repository__}
   Open http://localhost:{{port}}
   Log file: {DASHBOARD_LOG_FILE}
 """
@@ -355,7 +355,7 @@ def main():
     """CLI entry point."""
     parser = argparse.ArgumentParser(
         prog="copilot-dashboard",
-        description="Copilot Dashboard - monitor all your Copilot CLI sessions",
+        description="AI CLI Agent Dashboard - monitor all your Copilot CLI and Claude Code sessions",
         epilog=(
             "Examples:\n"
             "  copilot-dashboard start                  Start in foreground\n"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,11 +13,20 @@ from src.dashboard_api import API_TOKEN, app
 def client():
     """TestClient that automatically sends `Authorization: Bearer <token>`.
 
+    Uses `base_url="http://localhost"` so the Host header is "localhost",
+    which matches the production `TrustedHostMiddleware` allow-list. Without
+    this, TestClient would send `Host: testserver` and every request would
+    be rejected with HTTP 400 before reaching routing.
+
     This mirrors what the production frontend does. A separate test elsewhere
     exercises the legacy `?token=` query-string path for backwards
     compatibility.
     """
-    real_client = TestClient(app, headers={"Authorization": f"Bearer {API_TOKEN}"})
+    real_client = TestClient(
+        app,
+        base_url="http://localhost",
+        headers={"Authorization": f"Bearer {API_TOKEN}"},
+    )
     return real_client
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,30 +11,13 @@ from src.dashboard_api import API_TOKEN, app
 
 @pytest.fixture
 def client():
-    """TestClient that automatically includes the API auth token."""
-    real_client = TestClient(app)
-    original_get = real_client.get
-    original_post = real_client.post
-    original_put = real_client.put
+    """TestClient that automatically sends `Authorization: Bearer <token>`.
 
-    def _authed_get(url, **kwargs):
-        params = kwargs.pop("params", {}) or {}
-        params["token"] = API_TOKEN
-        return original_get(url, params=params, **kwargs)
-
-    def _authed_post(url, **kwargs):
-        params = kwargs.pop("params", {}) or {}
-        params["token"] = API_TOKEN
-        return original_post(url, params=params, **kwargs)
-
-    def _authed_put(url, **kwargs):
-        params = kwargs.pop("params", {}) or {}
-        params["token"] = API_TOKEN
-        return original_put(url, params=params, **kwargs)
-
-    real_client.get = _authed_get  # type: ignore[assignment]
-    real_client.post = _authed_post  # type: ignore[assignment]
-    real_client.put = _authed_put  # type: ignore[assignment]
+    This mirrors what the production frontend does. A separate test elsewhere
+    exercises the legacy `?token=` query-string path for backwards
+    compatibility.
+    """
+    real_client = TestClient(app, headers={"Authorization": f"Bearer {API_TOKEN}"})
     return real_client
 
 

--- a/tests/test_dashboard_api_extra.py
+++ b/tests/test_dashboard_api_extra.py
@@ -202,7 +202,7 @@ class TestIndexFallback:
         ):
             resp = client.get("/")
         assert resp.status_code == 200
-        assert "Copilot Dashboard" in resp.text
+        assert "AI CLI Agent Dashboard" in resp.text
         assert "No frontend build found" in resp.text
 
     def test_serves_dist_index_when_exists(self, client, tmp_path):

--- a/tests/test_dashboard_api_extra.py
+++ b/tests/test_dashboard_api_extra.py
@@ -77,7 +77,15 @@ class TestBackfillFromEvents:
         conn, db_path = mock_db
         conn.execute(
             "INSERT INTO sessions VALUES (?,?,?,?,?,?,?)",
-            ("sess-keep", "/original", "orig/repo", "main", "Test", "2026-01-01T00:00:00Z", "2026-01-02T00:00:00Z"),
+            (
+                "sess-keep",
+                "/original",
+                "orig/repo",
+                "main",
+                "Test",
+                "2026-01-01T00:00:00Z",
+                "2026-01-02T00:00:00Z",
+            ),
         )
         conn.commit()
 
@@ -106,7 +114,15 @@ class TestToolCounter:
         conn, db_path = mock_db
         conn.execute(
             "INSERT INTO sessions VALUES (?,?,?,?,?,?,?)",
-            ("sess-tc", "/project", "owner/repo", "main", "Test", "2026-01-01T00:00:00Z", "2026-01-02T00:00:00Z"),
+            (
+                "sess-tc",
+                "/project",
+                "owner/repo",
+                "main",
+                "Test",
+                "2026-01-01T00:00:00Z",
+                "2026-01-02T00:00:00Z",
+            ),
         )
         conn.commit()
 
@@ -137,7 +153,15 @@ class TestToolCounter:
         conn, db_path = mock_db
         conn.execute(
             "INSERT INTO sessions VALUES (?,?,?,?,?,?,?)",
-            ("sess-noev", "/project", "owner/repo", "main", "Test", "2026-01-01T00:00:00Z", "2026-01-02T00:00:00Z"),
+            (
+                "sess-noev",
+                "/project",
+                "owner/repo",
+                "main",
+                "Test",
+                "2026-01-01T00:00:00Z",
+                "2026-01-02T00:00:00Z",
+            ),
         )
         conn.commit()
 
@@ -181,9 +205,7 @@ class TestIndexFallback:
         dist_dir = str(tmp_path / "nonexistent_dist")
         templates_dir = tmp_path / "templates"
         templates_dir.mkdir()
-        (templates_dir / "dashboard.html").write_text(
-            "<html>{{ version }}</html>"
-        )
+        (templates_dir / "dashboard.html").write_text("<html>{{ version }}</html>")
         with (
             patch("src.dashboard_api.DIST_DIR", dist_dir),
             patch("src.dashboard_api.TEMPLATES_DIR", str(templates_dir)),
@@ -226,7 +248,7 @@ class TestAuthMiddleware:
     def test_api_rejects_no_token(self):
         from fastapi.testclient import TestClient
 
-        raw_client = TestClient(app)
+        raw_client = TestClient(app, base_url="http://localhost")
         resp = raw_client.get("/api/sessions")
         assert resp.status_code == 401
         assert resp.json() == {"error": "Unauthorized"}
@@ -234,7 +256,7 @@ class TestAuthMiddleware:
     def test_api_rejects_wrong_token(self):
         from fastapi.testclient import TestClient
 
-        raw_client = TestClient(app)
+        raw_client = TestClient(app, base_url="http://localhost")
         resp = raw_client.get("/api/sessions", params={"token": "bad-token"})
         assert resp.status_code == 401
 
@@ -243,17 +265,32 @@ class TestAuthMiddleware:
 
         from src.dashboard_api import API_TOKEN
 
-        raw_client = TestClient(app)
+        raw_client = TestClient(app, base_url="http://localhost")
         resp = raw_client.get(
             "/api/version",
             headers={"Authorization": f"Bearer {API_TOKEN}"},
         )
         assert resp.status_code == 200
 
+    def test_api_accepts_query_string_token_for_compat(self):
+        """Backwards-compatibility: the ?token= query string still works.
+
+        Production frontend uses Authorization: Bearer header, but the
+        backend continues to honor the legacy query-string for compat
+        with older bookmarks, in-page links, and scripted clients.
+        """
+        from fastapi.testclient import TestClient
+
+        from src.dashboard_api import API_TOKEN
+
+        raw_client = TestClient(app, base_url="http://localhost")
+        resp = raw_client.get("/api/version", params={"token": API_TOKEN})
+        assert resp.status_code == 200
+
     def test_root_accessible_without_token(self):
         from fastapi.testclient import TestClient
 
-        raw_client = TestClient(app)
+        raw_client = TestClient(app, base_url="http://localhost")
         resp = raw_client.get("/")
         assert resp.status_code == 200
 
@@ -262,7 +299,60 @@ class TestAuthMiddleware:
 
         from src.dashboard_api import API_TOKEN
 
-        raw_client = TestClient(app)
+        raw_client = TestClient(app, base_url="http://localhost")
         resp = raw_client.get("/")
         assert API_TOKEN in resp.text
         assert "__DASHBOARD_TOKEN__" in resp.text
+
+
+class TestTrustedHostMiddleware:
+    """Verify DNS-rebinding defense rejects unexpected Host headers."""
+
+    def test_evil_host_rejected(self):
+        """A request with `Host: evil.com` must be rejected with 400."""
+        from fastapi.testclient import TestClient
+
+        raw_client = TestClient(app, base_url="http://evil.com")
+        resp = raw_client.get("/")
+        assert resp.status_code == 400
+        # Starlette's default response text for TrustedHostMiddleware
+        assert "Invalid host header" in resp.text
+
+    def test_localhost_allowed(self):
+        from fastapi.testclient import TestClient
+
+        raw_client = TestClient(app, base_url="http://localhost")
+        resp = raw_client.get("/")
+        assert resp.status_code == 200
+
+    def test_loopback_ip_allowed(self):
+        from fastapi.testclient import TestClient
+
+        raw_client = TestClient(app, base_url="http://127.0.0.1")
+        resp = raw_client.get("/")
+        assert resp.status_code == 200
+
+
+class TestDocsDisabled:
+    """Verify Swagger UI and OpenAPI schema endpoints are disabled."""
+
+    def test_docs_returns_404(self):
+        from fastapi.testclient import TestClient
+
+        raw_client = TestClient(app, base_url="http://localhost")
+        resp = raw_client.get("/docs")
+        assert resp.status_code == 404
+
+    def test_openapi_returns_404(self):
+        from fastapi.testclient import TestClient
+
+        raw_client = TestClient(app, base_url="http://localhost")
+        resp = raw_client.get("/openapi.json")
+        assert resp.status_code == 404
+
+    def test_redoc_returns_404(self):
+        from fastapi.testclient import TestClient
+
+        raw_client = TestClient(app, base_url="http://localhost")
+        resp = raw_client.get("/redoc")
+        assert resp.status_code == 404

--- a/tests/test_dashboard_app.py
+++ b/tests/test_dashboard_app.py
@@ -472,7 +472,7 @@ class TestManifest:
         resp = client.get("/manifest.json")
         assert resp.status_code == 200
         data = resp.json()
-        assert data["name"] == "Copilot Dashboard"
+        assert data["name"] == "AI CLI Agent Dashboard"
         assert "icons" in data
         assert data["display"] == "standalone"
 

--- a/tests/test_process_tracker.py
+++ b/tests/test_process_tracker.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import threading
 import time
 from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock, patch
@@ -1693,3 +1694,139 @@ class TestFocusSessionWindow:
             ok, msg = focus_session_window("sess-1")
         assert ok is False
         assert "not supported" in msg.lower()
+
+
+# ---------------------------------------------------------------------------
+# get_running_sessions: window-title enrichment is async (perf regression test)
+# ---------------------------------------------------------------------------
+
+
+class TestEnrichmentIsAsync:
+    """Ensure window-title enrichment doesn't block the foreground request."""
+
+    def _wt_session(self) -> ProcessInfo:
+        return ProcessInfo(
+            pid=1234,
+            cmdline="copilot run",
+            terminal_name="WindowsTerminal.exe",
+            terminal_pid=999,
+        )
+
+    def test_cold_call_does_not_wait_for_uia(self, monkeypatch):
+        """If UIA hangs for 10s, get_running_sessions() must still return fast."""
+        from src import process_tracker as pt
+
+        # Reset cache + in-flight state
+        pt._running_cache.data = {}
+        pt._running_cache.time = 0
+        pt._enrichment_future = None
+
+        session = self._wt_session()
+
+        def fake_scan_windows():
+            return {"sess-A": session}
+
+        def fake_get_session_state(_sid):
+            return {"state": "idle", "waiting_context": None, "bg_tasks": 0, "bg_task_list": []}
+
+        slow_uia_started = threading.Event()
+        release = threading.Event()
+
+        def slow_populate(sessions):
+            slow_uia_started.set()
+            release.wait(timeout=5.0)  # held until test releases
+
+        monkeypatch.setattr(pt, "sys", type("S", (), {"platform": "win32"})())
+        monkeypatch.setattr(pt, "_get_running_sessions_windows", fake_scan_windows)
+        monkeypatch.setattr(pt, "_get_session_state", fake_get_session_state)
+        monkeypatch.setattr(pt, "_populate_window_titles", slow_populate)
+
+        try:
+            start = time.monotonic()
+            result = pt.get_running_sessions()
+            elapsed = time.monotonic() - start
+
+            # Must return well before the simulated UIA "hang" completes
+            assert elapsed < 2.0, f"get_running_sessions blocked for {elapsed:.2f}s"
+            assert "sess-A" in result
+
+            # Background thread should have started the slow work
+            assert slow_uia_started.wait(timeout=2.0), "Enrichment thread did not start"
+        finally:
+            release.set()
+            # Drain the in-flight future so it doesn't leak into the next test
+            if pt._enrichment_future is not None:
+                pt._enrichment_future.result(timeout=5.0)
+            pt._enrichment_future = None
+
+    def test_no_uia_when_no_windows_terminal_session(self, monkeypatch):
+        """If no session uses Windows Terminal, skip UIA entirely."""
+        from src import process_tracker as pt
+
+        pt._running_cache.data = {}
+        pt._running_cache.time = 0
+        pt._enrichment_future = None
+
+        non_wt = ProcessInfo(
+            pid=42, cmdline="copilot run", terminal_name="cmd.exe", terminal_pid=43
+        )
+        spawned = threading.Event()
+
+        def should_not_run(sessions):
+            spawned.set()
+
+        monkeypatch.setattr(pt, "sys", type("S", (), {"platform": "win32"})())
+        monkeypatch.setattr(pt, "_get_running_sessions_windows", lambda: {"sess-B": non_wt})
+        monkeypatch.setattr(
+            pt,
+            "_get_session_state",
+            lambda _sid: {"state": "idle", "waiting_context": None, "bg_tasks": 0, "bg_task_list": []},
+        )
+        monkeypatch.setattr(pt, "_populate_window_titles", should_not_run)
+
+        pt.get_running_sessions()
+        # Give a brief window for the executor to maybe spawn (it should not)
+        time.sleep(0.2)
+        assert not spawned.is_set(), "Should skip UIA enrichment when no WT session present"
+
+    def test_no_duplicate_background_jobs(self, monkeypatch):
+        """If a previous enrichment is still running, don't spawn another."""
+        from src import process_tracker as pt
+
+        pt._running_cache.data = {}
+        pt._running_cache.time = 0
+        pt._enrichment_future = None
+
+        session = self._wt_session()
+        call_count = [0]
+        release = threading.Event()
+
+        def slow_populate(sessions):
+            call_count[0] += 1
+            release.wait(timeout=5.0)  # block until test releases
+
+        monkeypatch.setattr(pt, "sys", type("S", (), {"platform": "win32"})())
+        monkeypatch.setattr(pt, "_get_running_sessions_windows", lambda: {"sess-C": session})
+        monkeypatch.setattr(
+            pt,
+            "_get_session_state",
+            lambda _sid: {"state": "idle", "waiting_context": None, "bg_tasks": 0, "bg_task_list": []},
+        )
+        monkeypatch.setattr(pt, "_populate_window_titles", slow_populate)
+
+        try:
+            # First cold call: spawns enrichment job 1
+            pt.get_running_sessions()
+            # Wait briefly so the executor picks up the job
+            time.sleep(0.1)
+
+            # Force cache expiry and call again — should NOT spawn job 2
+            pt._running_cache.time = 0
+            pt.get_running_sessions()
+            time.sleep(0.1)
+
+            assert call_count[0] == 1, f"Expected 1 enrichment job, got {call_count[0]}"
+        finally:
+            release.set()  # let the stuck thread exit cleanly
+
+


### PR DESCRIPTION
# Security + hygiene round (v0.10.0)

Holistic security audit + setup verification of the repo, with a full pass of fixes for everything found. 22 line-items addressed across 7 phases, plus a product rebrand. **No version bump in this PR — `release.yml` owns version bumping on `workflow_dispatch`; trigger it with `version_bump=minor` after merge to ship `v0.10.0`.**

## ⚠️ Pre-merge coordination items

- [ ] **(Optional) Verify branch protection on `main`** — `gh api repos/.../branches/main/protection` returned 404 during review. Either no rule exists, or the gh session lacked admin scope. Recommend: require PR review, require CI status checks, require CODEOWNERS review, disallow force-pushes.
- [ ] **(Optional) Regenerate `screenshot.png`** — current screenshot reveals internal Microsoft project/codename references via MCP server pills (`bluebird`, `kusto-1es`, `kusto-1esdevex`, `ado`, `workiq`, `es-chat`, `EFun`) and a session title (`Finding EFun project admins`). Title bar also shows the old `Copilot Dashboard` brand. Not blocking — flagged for you to decide.

## ⏭ Intentionally deferred to v0.10.1

Two changes touch the release path and were judged too risky to ship in the same PR as the very next release that uses them. Both will land in a follow-up once trusted publishing + GH App setup are verified:

1. **Drop `PYPI_API_TOKEN`** from `publish-pypi.yml` (OIDC is already wired at `id-token: write`, just needs PyPI trusted-publisher config confirmed for the workflow filename).
2. **Replace `PAT_TOKEN` in `release.yml`** with a GitHub App installation token (requires creating a release-bot GitHub App, installing it on the repo with `Contents: write` + `Pull requests: write`, and adding `RELEASE_APP_ID` + `RELEASE_APP_PRIVATE_KEY` secrets).

## What's in this PR

### Phase 1 — Repo-hygiene file additions
- **`SECURITY.md`** with private-vuln-reporting via GitHub Security Advisories
- **`.github/dependabot.yml`** for weekly pip/npm/actions updates
- **`.github/workflows/codeql.yml`** for Python + JavaScript/TS SAST
- README: refresh stale `New in v0.7` → `Recent additions`

### Phase 1.5 — Rebrand to "AI CLI Agent Dashboard"
- Honest about supporting both Copilot CLI **and** Claude Code; vendor-neutral and future-proof
- 12 user-facing strings updated (frontend H1, hamburger menu, browser notification, FastAPI title, PWA manifest `name` + `short_name: "AI Agents"`, CLI banner, argparse description, `frontend/index.html` browser tab, OpenAPI spec, README, CONTRIBUTING, docs)
- 11 internal docstrings updated for consistency
- 3 test assertions updated
- Header: removed "Created by Jeff Steinbok •" prefix; preserved clickable version-display widget; renamed `header-credits` div/CSS class to `header-version`. Mirrored in CLI banner.
- **Bonus fix**: `setup.py` URL typo (`ghcpCliSessionDashboard` → `ghcpCliDashboard`) and updated description to mention Claude Code
- **Out of scope** (intentionally untouched): `LICENSE` copyright, `setup.py` `author=`, `docs/_config.yml` copyright, repo name, PyPI package name

### Phase 2 — Frontend hardening
- **`fix-m3` Switch from `?token=` query string to `Authorization: Bearer` header** (eliminates token leakage via browser history, Referer header, JS error logs)
- **`fix-l1` PUT helper bug fix** — `put()` previously omitted auth, so PUT /api/settings 401'd in production despite passing tests. Automatically resolved by the M3 refactor (all helpers go through the same `authHeader()` path).
- **`fix-m1` `npm audit fix`** — cleared all 6 vulns (postcss, undici, vite, picomatch, flatted, brace-expansion) without `--force`. 0 vulnerabilities after fix.
- Backend `tests/conftest.py` switched to Bearer-header auth so tests mirror prod; added a separate raw test that exercises `?token=` query-string compat.

### Phase 3 — Backend security hardening
- **`fix-l3` DNS-rebinding defense** — `TrustedHostMiddleware(allowed_hosts=["127.0.0.1", "localhost"])`. Without this, a malicious page (DNS-rebound to 127.0.0.1) could load the dashboard and exfiltrate the token from `window.__DASHBOARD_TOKEN__`.
- **`fix-i1` Disable `/docs` + `/openapi.json` + `/redoc`** via `docs_url=None, redoc_url=None, openapi_url=None`. Removed the dead `_PUBLIC_PATH_PREFIXES` tuple that was never actually checked by the middleware. OpenAPI spec is still exported separately via `scripts.export_openapi` for the Jekyll docs site.
- **`fix-l2` CORS `allow_methods` += PUT** for consistency.
- **`fix-i2` `/api/update` script-builder hardening** — `json.dumps()` for all interpolated values so a future contributor can't accidentally introduce RCE.
- **`fix-i3` `/api/autostart/enable` port validation** — `int(port)` before interpolating into the Windows registry command line.
- New test classes: `TestTrustedHostMiddleware` (3 tests) and `TestDocsDisabled` (3 tests). 318 → 328 backend tests.

### Phase 4 — Performance (cold-call hang on Windows)
Two independent slow paths fixed:
1. `src/process_tracker.py`: window-title enrichment via UIA moved to a background thread (`ThreadPoolExecutor`, single worker, Future-based in-flight tracking, atomic cache swap, WT-presence pre-check). Cold call returns immediately without window titles; next request hits enriched cache.
2. `src/claude_code.py`: `get_running_claude_sessions()` now has a 5s TTL cache mirroring the Copilot path. Was completely uncached — root cause of repeated 30s PowerShell `Get-CimInstance` hangs on every `/api/sessions` call.

`TestEnrichmentIsAsync` (3 new tests): cold-call timing assertion, WT-pre-check skip, no duplicate background jobs.

**Known limitation**: discovered during live smoke that environments with **>10K session directories** still hit a separate bottleneck — `_SESSIONS_QUERY` has no `LIMIT` and iterates every row with per-row file reads. Tracked separately as a follow-up.

### Phase 5 — Python dependency pinning
Broad-range pins so end users don't hit pip-resolver conflicts:
- `requirements.txt`: `fastapi>=0.115,<1`, `uvicorn>=0.30,<1`, `platformdirs>=4,<5`, `pywinauto>=0.6,<1; sys_platform == "win32"`
- `requirements-dev.txt`: `pytest>=8,<9`, `pytest-cov>=5,<7`, `httpx>=0.27,<1`
- `setup.py`: removed duplicate `pywinauto` (was double-specified); `pywin32` stays

### Phase 6 — CI cleanup
- Removed dead `explore-typescript` branch from `ci.yml` push triggers (branch doesn't exist on remote — verified via `git branch -r`).

### Phase 7 — CI/CD supply chain (SHA-pin all GitHub Actions)
- **`fix-l4`** — 22 external action refs across 8 workflow files pinned to full 40-char commit SHAs. Original tag preserved as a comment for Dependabot tracking. Tag-pinning is vulnerable to tag-repoint attacks (e.g. the `tj-actions/changed-files` incident).
- Per rubber-duck: verified all tag refs resolved to commit-type objects directly (no annotated-tag indirection needed).

## Validation

| Check | Result |
|---|---|
| ruff check src/ | ✅ All checks passed |
| ruff format --check src/ | ✅ 12 files already formatted |
| mypy src/ | ✅ No issues, 12 source files |
| **pytest --cov=src** | ✅ **328 passed**, 79% coverage (up from 318) |
| npm audit (frontend) | ✅ **0 vulnerabilities** (was 6) |
| frontend eslint | ✅ Clean |
| frontend tsc --noEmit | ✅ Clean |
| **frontend vitest** | ✅ **203 passed** |
| frontend vite build | ✅ 192.95 KB JS / 60.35 KB gzipped |

### Live smoke test
- HTML `<title>` shows `AI CLI Agent Dashboard` ✅
- `Host: evil.com` → **400** (DNS rebinding blocked) ✅
- `/docs` → **404** (Swagger UI disabled) ✅
- `/api/server-info` no auth → **401** ✅
- `/api/server-info` Bearer header → **200** ✅
- `/api/server-info?token=...` legacy query-string → **200** (compat preserved) ✅

## Files changed
44 files, +714 / -210 lines, 8 phase commits (will squash-merge).

---
🤖 Generated with [GitHub Copilot CLI](https://github.com/cli/copilot-cli)