### PR TITLE
perf: faster process scanning + low-latency visibility-aware polling

### DIFF
--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -7,11 +7,21 @@
 
 // ── Polling & timing (milliseconds) ────────────────────────────────────────
 
-/** Fast poll for process state changes. */
-export const PROCESS_POLL_MS = 5_000;
+/**
+ * Fast poll for process state (working/thinking/waiting/idle) while the
+ * dashboard tab is visible. Kept low for snappy, near-real-time updates.
+ */
+export const PROCESS_POLL_MS = 1_000;
 
-/** Full session + process refetch interval. */
-export const SESSION_POLL_MS = 30_000;
+/** Full session + process refetch interval while the tab is visible. */
+export const SESSION_POLL_MS = 15_000;
+
+/**
+ * Slow process poll used only while the tab is hidden, purely to keep desktop
+ * notifications firing for state transitions. Disabled when notifications are
+ * off (nothing to do in the background).
+ */
+export const BACKGROUND_POLL_MS = 5_000;
 
 /** How often to re-check PyPI for a new version. */
 export const VERSION_CHECK_MS = 30 * 60 * 1_000;

--- a/frontend/src/hooks/useSessions.ts
+++ b/frontend/src/hooks/useSessions.ts
@@ -1,11 +1,21 @@
 import { useEffect, useRef } from "react";
 import { fetchSessions, fetchProcesses, fetchRemoteSessions } from "../api";
-import { PROCESS_POLL_MS, SESSION_POLL_MS } from "../constants";
+import { BACKGROUND_POLL_MS, PROCESS_POLL_MS, SESSION_POLL_MS } from "../constants";
 import { useAppState, useAppDispatch } from "../state";
 import type { ProcessMap } from "../types";
 
 /**
- * Polls /api/sessions every 30s and /api/processes every 5s.
+ * Polling driver for sessions and process state.
+ *
+ * Polling is Page Visibility-aware so latency is minimised when the user is
+ * actually looking at the dashboard, while resources are conserved otherwise:
+ *   - Visible: fast process-state poll (PROCESS_POLL_MS) + periodic full
+ *     session refetch (SESSION_POLL_MS). Becoming visible triggers an immediate
+ *     catch-up fetch so there is no wait for the next tick.
+ *   - Hidden: the fast/full polls are paused. A single slow poll
+ *     (BACKGROUND_POLL_MS) is kept alive ONLY when desktop notifications are
+ *     enabled, so state-transition alerts still fire while backgrounded.
+ *     With notifications off, polling stops entirely.
  */
 export function useSessions() {
   const dispatch = useAppDispatch();
@@ -80,12 +90,54 @@ export function useSessions() {
   };
 
   useEffect(() => {
-    fetchAll();
-    const activeTimer = setInterval(fetchProcs, PROCESS_POLL_MS);
-    const fullTimer = setInterval(fetchAll, SESSION_POLL_MS);
+    let fastTimer: ReturnType<typeof setInterval> | null = null;
+    let fullTimer: ReturnType<typeof setInterval> | null = null;
+    let bgTimer: ReturnType<typeof setInterval> | null = null;
+
+    const stop = (t: ReturnType<typeof setInterval> | null) => {
+      if (t !== null) clearInterval(t);
+    };
+
+    // Visible: snappy state poll + periodic full refresh.
+    const startForeground = () => {
+      stop(bgTimer);
+      bgTimer = null;
+      if (fastTimer === null) fastTimer = setInterval(fetchProcs, PROCESS_POLL_MS);
+      if (fullTimer === null) fullTimer = setInterval(fetchAll, SESSION_POLL_MS);
+    };
+
+    // Hidden: pause heavy polling; keep a slow poll only to drive desktop
+    // notifications, and only when they are enabled.
+    const startBackground = () => {
+      stop(fastTimer);
+      fastTimer = null;
+      stop(fullTimer);
+      fullTimer = null;
+      if (notifRef.current) {
+        if (bgTimer === null) bgTimer = setInterval(fetchProcs, BACKGROUND_POLL_MS);
+      } else {
+        stop(bgTimer);
+        bgTimer = null;
+      }
+    };
+
+    const handleVisibility = () => {
+      if (document.visibilityState === "visible") {
+        fetchAll(); // instant catch-up on focus
+        startForeground();
+      } else {
+        startBackground();
+      }
+    };
+
+    handleVisibility(); // kick off based on current visibility
+    document.addEventListener("visibilitychange", handleVisibility);
+
     return () => {
-      clearInterval(activeTimer);
-      clearInterval(fullTimer);
+      document.removeEventListener("visibilitychange", handleVisibility);
+      stop(fastTimer);
+      stop(fullTimer);
+      stop(bgTimer);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/frontend/src/test/hooks.test.ts
+++ b/frontend/src/test/hooks.test.ts
@@ -354,10 +354,69 @@ describe("useSessions", () => {
     const callCount = mockFetch.mock.calls.length;
 
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(5000); // PROCESS_POLL_MS
+      await vi.advanceTimersByTimeAsync(1000); // PROCESS_POLL_MS
     });
 
     // Should have made additional fetch calls for process polling
     expect(mockFetch.mock.calls.length).toBeGreaterThan(callCount);
+  });
+
+  it("pauses polling while the tab is hidden", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([]),
+    });
+
+    renderHook(() => useSessions(), { wrapper });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    // Go hidden — notifications are off by default, so polling stops entirely.
+    vi.spyOn(document, "visibilityState", "get").mockReturnValue("hidden");
+    await act(async () => {
+      document.dispatchEvent(new Event("visibilitychange"));
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    const callCount = mockFetch.mock.calls.length;
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_000); // well past every poll interval
+    });
+
+    // No further fetches while hidden
+    expect(mockFetch.mock.calls.length).toBe(callCount);
+    vi.restoreAllMocks();
+  });
+
+  it("fetches immediately when the tab becomes visible again", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([]),
+    });
+
+    renderHook(() => useSessions(), { wrapper });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    // Hide, then reveal.
+    const visibility = vi.spyOn(document, "visibilityState", "get");
+    visibility.mockReturnValue("hidden");
+    await act(async () => {
+      document.dispatchEvent(new Event("visibilitychange"));
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    const callCount = mockFetch.mock.calls.length;
+    visibility.mockReturnValue("visible");
+    await act(async () => {
+      document.dispatchEvent(new Event("visibilitychange"));
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    // Becoming visible triggers an immediate catch-up fetch (no wait for tick)
+    expect(mockFetch.mock.calls.length).toBeGreaterThan(callCount);
+    vi.restoreAllMocks();
   });
 });

--- a/src/claude_code.py
+++ b/src/claude_code.py
@@ -19,11 +19,9 @@ from datetime import UTC, datetime
 from .constants import (
     CLAUDE_PROJECTS_DIR,
     MAX_ANCESTRY_DEPTH,
-    PARENT_LOOKUP_TIMEOUT,
     POWERSHELL_TIMEOUT,
     PS_TIMEOUT,
     TERMINAL_NAMES,
-    UNIX_TERMINAL_SUBSTRINGS,
 )
 from .grouping import get_group_name
 from .models import ProcessInfo
@@ -521,6 +519,8 @@ def _get_running_claude_windows() -> dict[str, ProcessInfo]:
 
 def _get_running_claude_unix() -> dict[str, ProcessInfo]:
     """Find running claude processes on macOS/Linux via ps."""
+    from .process_tracker import build_unix_process_map, find_terminal_via_map
+
     result = subprocess.run(
         ["ps", "axo", "pid,ppid,command"],
         capture_output=True,
@@ -530,6 +530,9 @@ def _get_running_claude_unix() -> dict[str, ProcessInfo]:
     )
     if result.returncode != 0 or not result.stdout.strip():
         return {}
+
+    # Single ps call to build the full process tree; walked in memory below.
+    proc_map = build_unix_process_map()
 
     sessions: dict[str, ProcessInfo] = {}
     for line in result.stdout.strip().split("\n")[1:]:
@@ -546,32 +549,8 @@ def _get_running_claude_unix() -> dict[str, ProcessInfo]:
             continue
         cmd = parts[2]
 
-        # Walk up process tree to find terminal PID
-        terminal_pid = 0
-        terminal_name = ""
-        try:
-            cur_ppid = ppid
-            for _ in range(5):
-                parent_result = subprocess.run(
-                    ["ps", "-p", str(cur_ppid), "-o", "ppid=,comm="],
-                    capture_output=True,
-                    text=True,
-                    timeout=PARENT_LOOKUP_TIMEOUT,
-                    check=False,
-                )
-                if parent_result.returncode != 0 or not parent_result.stdout.strip():
-                    break
-                pinfo = parent_result.stdout.strip().split(None, 1)
-                if len(pinfo) < 2:
-                    break
-                pname = pinfo[1].strip().lower()
-                if any(t in pname for t in UNIX_TERMINAL_SUBSTRINGS):
-                    terminal_pid = cur_ppid
-                    terminal_name = pinfo[1].strip()
-                    break
-                cur_ppid = int(pinfo[0])
-        except Exception:
-            pass
+        # Walk up process tree (in memory) to find terminal PID
+        terminal_pid, terminal_name = find_terminal_via_map(ppid, proc_map, MAX_ANCESTRY_DEPTH)
 
         proc_info = ProcessInfo(
             pid=pid,

--- a/src/constants.py
+++ b/src/constants.py
@@ -46,8 +46,12 @@ CLAUDE_PROJECTS_DIR = os.path.join(CLAUDE_DIR, "projects")
 
 # ── Polling & cache intervals (seconds) ──────────────────────────────────────
 
-RUNNING_CACHE_TTL = 5
-"""How long to cache the result of get_running_sessions()."""
+RUNNING_CACHE_TTL = 1
+"""How long (seconds) to cache the result of get_running_sessions().
+
+Kept low so the dashboard's fast (≈1s) visible-tab poll receives near-real-time
+state. It still coalesces bursts/multiple tabs into at most one process scan per
+second; warm scans are ~0.1s, so this is cheap."""
 
 VERSION_CACHE_TTL = 1800
 """How often to re-check PyPI for a new version (30 minutes)."""

--- a/src/process_tracker.py
+++ b/src/process_tracker.py
@@ -24,7 +24,6 @@ from .constants import (
     MAX_UNIX_PARENT_DEPTH,
     OSASCRIPT_TIMEOUT,
     OUTPUT_TAIL_BUFFER,
-    PARENT_LOOKUP_TIMEOUT,
     POWERSHELL_TIMEOUT,
     PROCESS_MATCH_TOLERANCE,
     PS_TIMEOUT,
@@ -53,6 +52,12 @@ _running_lock = threading.Lock()
 # context, intent). Active sessions are re-read each poll; inactive ones are
 # cached forever since their events.jsonl won't change.
 _event_data_cache: dict[str, EventData] = {}
+
+# Cache of parsed session.start/session.resume timestamps per events.jsonl file,
+# keyed by file path -> (mtime, size, [datetimes]). Lets us skip re-parsing the
+# (potentially huge) event logs of unchanged sessions on every poll. Guarded by
+# _running_lock, since it is only touched from the get_running_sessions() path.
+_lifecycle_cache: dict[str, tuple[float, int, list[datetime]]] = {}
 
 
 def _read_recent_events(session_id, count=10):
@@ -243,7 +248,75 @@ def _parse_iso_timestamp(ts_str):
     return datetime.fromisoformat(ts_str)
 
 
-def _match_process_to_session(creation_date_str):
+def _parse_lifecycle_timestamps(events_file: str) -> list[datetime]:
+    """Parse session.start/session.resume timestamps from one events.jsonl.
+
+    Uses a cheap substring pre-filter so ``json.loads`` is only run on the
+    handful of lifecycle lines rather than every event in the log (event logs
+    are dominated by tool/message events and can be many megabytes).
+    """
+    timestamps: list[datetime] = []
+    try:
+        with open(events_file, encoding="utf-8", errors="replace") as f:
+            for line in f:
+                # Skip non-lifecycle lines without paying for JSON parsing.
+                if "session.start" not in line and "session.resume" not in line:
+                    continue
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    evt = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if evt.get("type") not in ("session.start", "session.resume"):
+                    continue
+                ts = evt.get("timestamp", "")
+                if not ts:
+                    continue
+                try:
+                    timestamps.append(_parse_iso_timestamp(ts))
+                except (ValueError, TypeError, AttributeError):
+                    continue
+    except OSError as e:
+        logger.debug("Error reading lifecycle events from %s: %s", events_file, e)
+    return timestamps
+
+
+def _build_lifecycle_index() -> dict[str, list[datetime]]:
+    """Map each session ID to its parsed lifecycle event timestamps.
+
+    Scans every session's events.jsonl once and caches the result per file
+    (keyed by mtime+size), so unchanged sessions are never re-parsed on later
+    polls — only new or actively written logs are read again. Building this
+    index once per process scan avoids re-walking thousands of session files
+    for every unmatched process.
+    """
+    index: dict[str, list[datetime]] = {}
+    if not os.path.isdir(EVENTS_DIR):
+        return index
+    try:
+        sids = os.listdir(EVENTS_DIR)
+    except OSError:
+        return index
+    for sid in sids:
+        events_file = os.path.join(EVENTS_DIR, sid, "events.jsonl")
+        try:
+            st = os.stat(events_file)
+        except OSError:
+            continue
+        cached = _lifecycle_cache.get(events_file)
+        if cached is not None and cached[0] == st.st_mtime and cached[1] == st.st_size:
+            timestamps = cached[2]
+        else:
+            timestamps = _parse_lifecycle_timestamps(events_file)
+            _lifecycle_cache[events_file] = (st.st_mtime, st.st_size, timestamps)
+        if timestamps:
+            index[sid] = timestamps
+    return index
+
+
+def _match_process_to_session(creation_date_str, index=None):
     """Match a copilot.exe process (without --resume) to a session by creation time.
 
     Compares the process creation time to the session lifecycle timestamps found
@@ -251,49 +324,29 @@ def _match_process_to_session(creation_date_str):
     because resumed sessions may no longer expose ``--resume <id>`` in the live
     process command line. Returns the session ID with the closest match within
     the configured tolerance window.
+
+    ``index`` is an optional prebuilt ``{session_id: [datetimes]}`` map (see
+    :func:`_build_lifecycle_index`). Pass it when matching many processes in a
+    loop so the session logs are only scanned once; it is built on demand when
+    omitted.
     """
     try:
         proc_time = _parse_iso_timestamp(creation_date_str)
     except (ValueError, TypeError, AttributeError):
         return None
 
-    if not os.path.isdir(EVENTS_DIR):
-        return None
+    if index is None:
+        index = _build_lifecycle_index()
 
     best_sid = None
     best_delta = PROCESS_MATCH_TOLERANCE
 
-    for sid in os.listdir(EVENTS_DIR):
-        events_file = os.path.join(EVENTS_DIR, sid, "events.jsonl")
-        if not os.path.exists(events_file):
-            continue
-        try:
-            lifecycle_timestamps = []
-            with open(events_file, encoding="utf-8", errors="replace") as f:
-                for line in f:
-                    line = line.strip()
-                    if not line:
-                        continue
-                    try:
-                        evt = json.loads(line)
-                    except json.JSONDecodeError:
-                        continue
-                    if evt.get("type") not in ("session.start", "session.resume"):
-                        continue
-                    ts = evt.get("timestamp", "")
-                    if ts:
-                        lifecycle_timestamps.append(ts)
-            if not lifecycle_timestamps:
-                continue
-            for ts in lifecycle_timestamps:
-                evt_time = _parse_iso_timestamp(ts)
-                delta = abs((proc_time - evt_time).total_seconds())
-                if delta <= best_delta:
-                    best_delta = delta
-                    best_sid = sid
-        except Exception as e:
-            logger.debug("Error matching session %s: %s", sid, e)
-            continue
+    for sid, timestamps in index.items():
+        for evt_time in timestamps:
+            delta = abs((proc_time - evt_time).total_seconds())
+            if delta <= best_delta:
+                best_delta = delta
+                best_sid = sid
 
     return best_sid
 
@@ -377,16 +430,74 @@ def _get_running_sessions_windows() -> dict[str, ProcessInfo]:
             # No --resume flag — try to match by creation time
             unmatched.append((proc, proc_info))
 
-    # Match non-resume processes to sessions by creation timestamp
+    # Match non-resume processes to sessions by creation timestamp. Build the
+    # lifecycle index once and reuse it for every unmatched process.
+    lifecycle_index = _build_lifecycle_index() if unmatched else {}
     for proc, proc_info in unmatched:
         created = proc.get("CreatedUTC", "")
-        sid = _match_process_to_session(created)
+        sid = _match_process_to_session(created, lifecycle_index)
         if sid:
             # Prefer this over a previously unmatched entry, but don't clobber --resume matches
             if sid not in sessions or "--resume" not in sessions[sid].cmdline:
                 sessions[sid] = proc_info
 
     return sessions
+
+
+def build_unix_process_map() -> dict[int, tuple[int, str]]:
+    """Return a ``{pid: (ppid, comm)}`` map of all processes via one ps call.
+
+    Walking the process tree by spawning ``ps -p <pid>`` once per ancestor is
+    O(matched processes * depth) subprocess spawns, which costs seconds when
+    many Copilot/Claude processes are running. Building this map up front lets
+    callers walk the tree in memory instead, turning that into a single ps call.
+    """
+    proc_map: dict[int, tuple[int, str]] = {}
+    try:
+        result = subprocess.run(
+            ["ps", "axo", "pid=,ppid=,comm="],
+            capture_output=True,
+            text=True,
+            timeout=PS_TIMEOUT,
+            check=False,
+        )
+    except Exception as e:
+        logger.debug("Error building process map: %s", e)
+        return proc_map
+    if result.returncode != 0 or not result.stdout.strip():
+        return proc_map
+    for line in result.stdout.strip().split("\n"):
+        # comm may contain spaces (full path on macOS) — keep it as the remainder
+        parts = line.split(None, 2)
+        if len(parts) < 3:
+            continue
+        try:
+            pid = int(parts[0])
+            ppid = int(parts[1])
+        except (ValueError, IndexError):
+            continue
+        proc_map[pid] = (ppid, parts[2])
+    return proc_map
+
+
+def find_terminal_via_map(
+    ppid: int, proc_map: dict[int, tuple[int, str]], max_depth: int
+) -> tuple[int, str]:
+    """Walk up the process tree in memory to find the controlling terminal.
+
+    Returns ``(terminal_pid, terminal_name)``, or ``(0, "")`` if none is found
+    within ``max_depth`` ancestors.
+    """
+    cur_ppid = ppid
+    for _ in range(max_depth):
+        entry = proc_map.get(cur_ppid)
+        if entry is None:
+            break
+        next_ppid, comm = entry
+        if any(t in comm.lower() for t in UNIX_TERMINAL_SUBSTRINGS):
+            return cur_ppid, comm
+        cur_ppid = next_ppid
+    return 0, ""
 
 
 def _get_running_sessions_unix() -> dict[str, ProcessInfo]:
@@ -401,7 +512,13 @@ def _get_running_sessions_unix() -> dict[str, ProcessInfo]:
     if result.returncode != 0 or not result.stdout.strip():
         return {}
 
+    # Single ps call to build the full process tree; walked in memory below.
+    proc_map = build_unix_process_map()
+
     sessions: dict[str, ProcessInfo] = {}
+    # Built lazily on the first non-resume process, then reused for the rest so
+    # the session logs are scanned at most once per call.
+    lifecycle_index: dict[str, list[datetime]] | None = None
     for line in result.stdout.strip().split("\n")[1:]:
         line = line.strip()
         # Match copilot binary (copilot or copilot.exe, or node ... copilot)
@@ -419,48 +536,12 @@ def _get_running_sessions_unix() -> dict[str, ProcessInfo]:
         lstart_str = " ".join(parts_line[2:7])
         cmd = parts_line[7]
 
-        # Walk up process tree to find terminal PID
-        terminal_pid = 0
-        terminal_name = ""
-        try:
-            cur_ppid = ppid
-            for _ in range(MAX_UNIX_PARENT_DEPTH):
-                parent_result = subprocess.run(
-                    ["ps", "-p", str(cur_ppid), "-o", "ppid=,comm="],
-                    capture_output=True,
-                    text=True,
-                    timeout=PARENT_LOOKUP_TIMEOUT,
-                    check=False,
-                )
-                if parent_result.returncode != 0 or not parent_result.stdout.strip():
-                    break
-                pinfo = parent_result.stdout.strip().split(None, 1)
-                if len(pinfo) < 2:
-                    break
-                pname = pinfo[1].strip().lower()
-                # Check if this is a terminal application
-                if any(t in pname for t in UNIX_TERMINAL_SUBSTRINGS):
-                    terminal_pid = cur_ppid
-                    terminal_name = pinfo[1].strip()
-                    break
-                cur_ppid = int(pinfo[0])
-        except Exception as e:
-            logger.debug("Error walking process tree from PID %d: %s", ppid, e)
+        # Walk up process tree (in memory) to find terminal PID
+        terminal_pid, terminal_name = find_terminal_via_map(ppid, proc_map, MAX_UNIX_PARENT_DEPTH)
 
         # Detect if launched via agency (check parent command)
-        is_agency = False
-        try:
-            parent_result = subprocess.run(
-                ["ps", "-p", str(ppid), "-o", "comm="],
-                capture_output=True,
-                text=True,
-                timeout=PARENT_LOOKUP_TIMEOUT,
-                check=False,
-            )
-            if parent_result.returncode == 0:
-                is_agency = parent_result.stdout.strip().lower().endswith("agency")
-        except Exception:
-            pass
+        parent_entry = proc_map.get(ppid)
+        is_agency = bool(parent_entry and parent_entry[1].lower().endswith("agency"))
 
         proc_info = ProcessInfo(
             pid=pid,
@@ -485,7 +566,9 @@ def _get_running_sessions_unix() -> dict[str, ProcessInfo]:
         try:
             proc_time = datetime.strptime(lstart_str, "%a %b %d %H:%M:%S %Y")
             proc_time = proc_time.astimezone(UTC)
-            sid = _match_process_to_session(proc_time.isoformat())
+            if lifecycle_index is None:
+                lifecycle_index = _build_lifecycle_index()
+            sid = _match_process_to_session(proc_time.isoformat(), lifecycle_index)
             if sid and sid not in sessions:
                 sessions[sid] = proc_info
         except Exception as e:

--- a/tests/test_process_tracker.py
+++ b/tests/test_process_tracker.py
@@ -21,6 +21,8 @@ from src.process_tracker import (
     _read_event_data,
     _read_recent_events,
     _running_cache,
+    build_unix_process_map,
+    find_terminal_via_map,
     get_recent_output,
     get_running_sessions,
     get_session_event_data,
@@ -646,6 +648,62 @@ class TestGetSessionStateAdditional:
 
 
 # ---------------------------------------------------------------------------
+# build_unix_process_map / find_terminal_via_map
+# ---------------------------------------------------------------------------
+
+
+class TestUnixProcessMap:
+    """Tests for the in-memory process-tree helpers."""
+
+    def test_build_map_parses_pid_ppid_comm(self):
+        out = "9643 4510 copilot\n4510 1000 bash\n1000 1 /Applications/iTerm.app/Contents/MacOS/iTerm2\n"
+        mock = MagicMock(returncode=0, stdout=out)
+        with patch("src.process_tracker.subprocess.run", return_value=mock):
+            proc_map = build_unix_process_map()
+        assert proc_map[9643] == (4510, "copilot")
+        assert proc_map[4510] == (1000, "bash")
+        # comm with spaces (full path) is preserved as the remainder
+        assert proc_map[1000][0] == 1
+        assert proc_map[1000][1].endswith("iTerm2")
+
+    def test_build_map_skips_malformed_and_header_lines(self):
+        out = "PID PPID COMM\n9643 4510 copilot\njunk\n123\n"
+        mock = MagicMock(returncode=0, stdout=out)
+        with patch("src.process_tracker.subprocess.run", return_value=mock):
+            proc_map = build_unix_process_map()
+        assert proc_map == {9643: (4510, "copilot")}
+
+    def test_build_map_returns_empty_on_failure(self):
+        mock = MagicMock(returncode=1, stdout="")
+        with patch("src.process_tracker.subprocess.run", return_value=mock):
+            assert build_unix_process_map() == {}
+
+    def test_build_map_returns_empty_on_exception(self):
+        with patch(
+            "src.process_tracker.subprocess.run", side_effect=OSError("boom")
+        ):
+            assert build_unix_process_map() == {}
+
+    def test_find_terminal_walks_up_to_terminal(self):
+        proc_map = {9643: (4510, "copilot"), 4510: (1000, "bash"), 1000: (1, "iTerm2")}
+        pid, name = find_terminal_via_map(4510, proc_map, 5)
+        assert pid == 1000
+        assert name == "iTerm2"
+
+    def test_find_terminal_returns_zero_when_none_found(self):
+        proc_map = {4510: (1000, "bash"), 1000: (1, "launchd")}
+        assert find_terminal_via_map(4510, proc_map, 5) == (0, "")
+
+    def test_find_terminal_respects_max_depth(self):
+        # Terminal is 3 hops up but max_depth is 2 — should not be found
+        proc_map = {10: (20, "a"), 20: (30, "b"), 30: (1, "warp")}
+        assert find_terminal_via_map(10, proc_map, 2) == (0, "")
+
+    def test_find_terminal_handles_missing_pid(self):
+        assert find_terminal_via_map(999, {}, 5) == (0, "")
+
+
+# ---------------------------------------------------------------------------
 # _get_running_sessions_unix (lines 323-406)
 # ---------------------------------------------------------------------------
 
@@ -733,17 +791,16 @@ class TestGetRunningSessionsUnix:
             " 9643  4510 Wed Feb 25 21:15:57 2026 /opt/homebrew/lib/node_modules/@github/copilot/copilot --resume sess-term",
         ])
         mock_ps = MagicMock(returncode=0, stdout=ps_out)
-        call_count = [0]
+        # Process map (pid ppid comm) walked in memory: 4510 bash -> 1000 iTerm2
+        proc_map_out = "9643 4510 copilot\n4510 1000 bash\n1000 1 iTerm2\n"
+        mock_map = MagicMock(returncode=0, stdout=proc_map_out)
 
         def run_side_effect(args, **kw):
+            if "pid=,ppid=,comm=" in args:
+                return mock_map
             if "axo" in args:
                 return mock_ps
-            call_count[0] += 1
-            if call_count[0] == 1:
-                # First parent (pid 4510) is bash — not a terminal
-                return MagicMock(returncode=0, stdout="  1000 bash")
-            # Second parent (pid 1000) is iTerm2 — terminal found
-            return MagicMock(returncode=0, stdout="     1 iTerm2")
+            return MagicMock(returncode=1, stdout="")
 
         with patch("src.process_tracker.subprocess.run", side_effect=run_side_effect):
             sessions = _get_running_sessions_unix()


### PR DESCRIPTION
## Summary

Two related improvements: the dashboard was extremely slow to load sessions (process scan took 11s+), and live updates lagged. This makes scanning near-instant and updates much more responsive while idle tabs stay cheap.

## Backend — process scanning
- **Single `ps` snapshot instead of N subprocess spawns.** `build_unix_process_map()` takes one `ps axo pid=,ppid=,comm=` call and `find_terminal_via_map()` walks the process tree in memory, replacing hundreds of per-process `ps -p` spawns per poll.
- **Lifecycle index built once per scan.** A per-file (mtime+size) cache parses each `events.jsonl` at most once per scan instead of re-scanning all session dirs for every unmatched process; a cheap substring pre-filter skips `json.loads` on non-lifecycle lines.
- `claude_code` reuses the shared process-map helpers.
- `RUNNING_CACHE_TTL` 5 → 1 for fresher state.

**Result:** `/api/processes` warm ~0.08s (was 11s+); `/api/sessions` warm ~0.17s.

## Frontend — low-latency, visibility-aware polling
- When the tab is **focused**: process-state poll every **1s**, full session refresh every **15s**.
- When the tab is **hidden**: pause heavy polling; keep only a **5s** background poll when desktop notifications are enabled (so notifications still fire), otherwise fully pause.
- Immediate catch-up fetch on becoming visible again.
- Constants: `PROCESS_POLL_MS` 5000 → 1000, `SESSION_POLL_MS` 30000 → 15000, add `BACKGROUND_POLL_MS` 5000.

## Tests
- Added `TestUnixProcessMap` coverage for the new process-map helpers.
- Added hook tests for pause-while-hidden and fetch-on-revisible.
- Backend: 326 tests pass; `ruff check src/`, `ruff format --check src/`, `mypy src/` clean.
- Frontend: 205 tests pass; `npm run build` succeeds.

Behavior/feature parity is preserved — only *how* data is gathered and *how often* it refreshes changed.