### PR TITLE
chore: update jekyll-build-pages to v2

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Build with Jekyll
-        uses: actions/jekyll-build-pages@v1
+        uses: actions/jekyll-build-pages@v2
         with:
           source: ./docs
           destination: ./_site


### PR DESCRIPTION
Updates actions/jekyll-build-pages from v1 to v2 for latest features and security fixes.