### PR TITLE
Fix Windows dashboard process scan popups

### DIFF
--- a/src/process_tracker.py
+++ b/src/process_tracker.py
@@ -37,6 +37,7 @@ from .models import BackgroundTask, EventData, ProcessInfo, RunningCache, Sessio
 logger = logging.getLogger(__name__)
 
 EVENTS_DIR = SESSION_STATE_DIR
+CREATE_NO_WINDOW = getattr(subprocess, "CREATE_NO_WINDOW", 0x08000000)
 
 # Tool names that indicate "waiting for user input"
 WAITING_TOOLS = frozenset({"ask_user", "ask_permission"})
@@ -360,12 +361,18 @@ def _get_running_sessions_windows() -> dict[str, ProcessInfo]:
         "@{N='CreatedUTC';E={$_.CreationDate.ToUniversalTime().ToString('o')}} | "
         "ConvertTo-Json -Depth 2"
     )
+    kwargs: dict = {
+        "capture_output": True,
+        "text": True,
+        "timeout": POWERSHELL_TIMEOUT,
+        "check": False,
+    }
+    if sys.platform == "win32":
+        kwargs["creationflags"] = CREATE_NO_WINDOW
+
     result = subprocess.run(
         ["powershell", "-NoProfile", "-Command", ps_script],
-        capture_output=True,
-        text=True,
-        timeout=POWERSHELL_TIMEOUT,
-        check=False,
+        **kwargs,
     )
     if result.returncode != 0 or not result.stdout.strip():
         return {}

--- a/tests/test_process_tracker.py
+++ b/tests/test_process_tracker.py
@@ -10,6 +10,7 @@ import pytest
 
 from src.models import ProcessInfo, SessionState
 from src.process_tracker import (
+    CREATE_NO_WINDOW,
     _event_data_cache,
     _get_live_branch,
     _get_running_sessions_unix,
@@ -872,6 +873,17 @@ class TestGetRunningSessionsWindows:
 
         assert "win-sess-001" in sessions
         assert sessions["win-sess-001"].pid == 1234
+
+    def test_powershell_scan_uses_hidden_window_on_windows(self):
+        mock_result = MagicMock(returncode=0, stdout="[]")
+
+        with (
+            patch("src.process_tracker.sys.platform", "win32"),
+            patch("src.process_tracker.subprocess.run", return_value=mock_result) as mock_run,
+        ):
+            _get_running_sessions_windows()
+
+        assert mock_run.call_args.kwargs["creationflags"] == CREATE_NO_WINDOW
 
     def test_timestamp_matching_for_no_resume(self):
         procs = [


### PR DESCRIPTION
## Summary
- Hide the Windows PowerShell process scanner used by dashboard polling so it no longer flashes console windows.
- Add regression coverage for the hidden-window creation flag.

## Validation
- ruff check src
- pytest tests/test_process_tracker.py::TestGetRunningSessionsWindows::test_powershell_scan_uses_hidden_window_on_windows -q

Note: python -m mypy src currently fails on existing Windows-local baseline issues in tray_app.py and session_dashboard.py unrelated to this change.