### PR TITLE
Fix Claude scanner popups and enlarge title

### DIFF
--- a/frontend/src/themes.css
+++ b/frontend/src/themes.css
@@ -197,7 +197,7 @@ a:hover { text-decoration: underline; }
   position: sticky; top: 0; z-index: 100; flex-wrap: wrap;
 }
 .header .logo { font-size: 22px; }
-.header h1 { font-size: 22px; font-weight: 600; white-space: nowrap; }
+.header h1 { font-size: 28px; font-weight: 700; line-height: 1.1; white-space: nowrap; }
 .brand { display: flex; align-items: baseline; gap: 12px; flex-wrap: wrap; }
 .about-title { display: flex; align-items: center; gap: 10px; }
 .about-logo { height: 40px; width: auto; vertical-align: middle; }

--- a/src/claude_code.py
+++ b/src/claude_code.py
@@ -27,6 +27,7 @@ from .grouping import get_group_name
 from .models import ProcessInfo
 
 logger = logging.getLogger(__name__)
+CREATE_NO_WINDOW = getattr(subprocess, "CREATE_NO_WINDOW", 0x08000000)
 
 # Prefix to namespace Claude session IDs and avoid collisions with Copilot UUIDs
 SESSION_ID_PREFIX = "cc:"
@@ -458,12 +459,18 @@ def _get_running_claude_windows() -> dict[str, ProcessInfo]:
         "@{N='CreatedUTC';E={$_.CreationDate.ToUniversalTime().ToString('o')}} | "
         "ConvertTo-Json -Depth 2"
     )
+    kwargs: dict = {
+        "capture_output": True,
+        "text": True,
+        "timeout": POWERSHELL_TIMEOUT,
+        "check": False,
+    }
+    if sys.platform == "win32":
+        kwargs["creationflags"] = CREATE_NO_WINDOW
+
     result = subprocess.run(
         ["powershell", "-NoProfile", "-Command", ps_script],
-        capture_output=True,
-        text=True,
-        timeout=POWERSHELL_TIMEOUT,
-        check=False,
+        **kwargs,
     )
     if result.returncode != 0 or not result.stdout.strip():
         return {}

--- a/tests/test_claude_code.py
+++ b/tests/test_claude_code.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 import pytest
 
 from src.claude_code import (
+    CREATE_NO_WINDOW,
     SESSION_ID_PREFIX,
     _build_restart_cmd,
     _decode_project_dir,
@@ -19,7 +20,6 @@ from src.claude_code import (
     get_claude_session_detail,
     get_claude_sessions,
 )
-
 
 # ── Fixtures ─────────────────────────────────────────────────────────────────
 
@@ -457,3 +457,17 @@ class TestProcessStateDefaults:
         proc = result[f"{SESSION_ID_PREFIX}test-session-1"]
         assert proc.state == "idle"
         assert "waiting for user message" in proc.waiting_context
+
+    def test_windows_process_scan_uses_hidden_window(self):
+        """Claude process scans should not flash PowerShell windows."""
+        from src.claude_code import _get_running_claude_windows
+
+        with (
+            patch("src.claude_code.sys.platform", "win32"),
+            patch("src.claude_code.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value.returncode = 0
+            mock_run.return_value.stdout = "[]"
+            _get_running_claude_windows()
+
+        assert mock_run.call_args.kwargs["creationflags"] == CREATE_NO_WINDOW


### PR DESCRIPTION
## Summary
- Hide the Windows PowerShell scanner used for Claude Code process detection so dashboard polling does not flash console windows.
- Make the Agent Eye header title larger and bolder.
- Add regression coverage for the hidden Claude scanner subprocess.

## Validation
- npm run build
- ruff check src tests/test_claude_code.py
- pytest tests/test_claude_code.py::TestProcessStateDefaults::test_windows_process_scan_uses_hidden_window tests/test_process_tracker.py::TestGetRunningSessionsWindows::test_powershell_scan_uses_hidden_window_on_windows -q