### PR TITLE
feat: detect VS Code Copilot sessions as active + fix settings auth

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -46,7 +46,7 @@ async function post<T>(url: string): Promise<T> {
 
 /** Generic PUT+JSON helper — throws on non-2xx responses. */
 async function put<T>(url: string, body: unknown): Promise<T> {
-  const resp = await fetch(url, {
+  const resp = await fetch(withToken(url), {
     method: "PUT",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),

--- a/frontend/src/components/HamburgerMenu.tsx
+++ b/frontend/src/components/HamburgerMenu.tsx
@@ -21,7 +21,7 @@ export default function HamburgerMenu() {
   const menuRef = useRef<HTMLDivElement>(null);
 
   const autostart = useAutostart();
-  const { settings, loading: settingsLoading, setSyncEnabled, setLogLevel } = useSettings();
+  const { settings, loading: settingsLoading, setSyncEnabled, setLogLevel, setMtimeThreshold } = useSettings();
 
   const toggle = useCallback(() => setOpen((prev) => !prev), []);
 
@@ -109,6 +109,23 @@ export default function HamburgerMenu() {
                   <option value="INFO">INFO</option>
                   <option value="WARNING">WARNING</option>
                   <option value="ERROR">ERROR</option>
+                </select>
+              </label>
+            )}
+
+            {/* Active detection threshold */}
+            {!settingsLoading && (
+              <label className="hamburger-item hamburger-select" role="menuitem" title="How many seconds of inactivity before a VS Code session is considered inactive">
+                <span>Active timeout</span>
+                <select
+                  value={settings.mtime_active_threshold}
+                  onChange={(e) => setMtimeThreshold(Number(e.target.value))}
+                >
+                  <option value={60}>60s</option>
+                  <option value={120}>120s</option>
+                  <option value={180}>180s</option>
+                  <option value={300}>5min</option>
+                  <option value={600}>10min</option>
                 </select>
               </label>
             )}

--- a/frontend/src/hooks/useSettings.ts
+++ b/frontend/src/hooks/useSettings.ts
@@ -9,6 +9,7 @@ import type { DashboardSettings } from "../types";
 const DEFAULT_SETTINGS: DashboardSettings = {
   sync_enabled: true,
   log_level: "INFO",
+  mtime_active_threshold: 120,
 };
 
 export interface UseSettingsResult {
@@ -16,6 +17,7 @@ export interface UseSettingsResult {
   loading: boolean;
   setSyncEnabled: (enabled: boolean) => void;
   setLogLevel: (level: string) => void;
+  setMtimeThreshold: (seconds: number) => void;
 }
 
 export function useSettings(): UseSettingsResult {
@@ -43,5 +45,12 @@ export function useSettings(): UseSettingsResult {
       .catch(() => {});
   }, []);
 
-  return { settings, loading, setSyncEnabled, setLogLevel };
+  const setMtimeThreshold = useCallback((seconds: number) => {
+    setSettings((prev) => ({ ...prev, mtime_active_threshold: seconds }));
+    updateSettings({ mtime_active_threshold: seconds })
+      .then(setSettings)
+      .catch(() => {});
+  }, []);
+
+  return { settings, loading, setSyncEnabled, setLogLevel, setMtimeThreshold };
 }

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -128,4 +128,5 @@ export interface AutostartStatus {
 export interface DashboardSettings {
   sync_enabled: boolean;
   log_level: string;
+  mtime_active_threshold: number;
 }

--- a/src/constants.py
+++ b/src/constants.py
@@ -59,6 +59,11 @@ VERSION_CACHE_TTL = 1800
 EVENT_STALENESS_THRESHOLD = 60
 """Events older than this (seconds) are treated as stale / likely buffered."""
 
+MTIME_ACTIVE_THRESHOLD = 120
+"""Sessions whose events.jsonl was modified within this many seconds are
+considered active even without a matched process.  Covers VS Code integrated
+Copilot CLI sessions which don't spawn a standalone copilot.exe."""
+
 # ── Subprocess timeouts (seconds) ────────────────────────────────────────────
 
 POWERSHELL_TIMEOUT = 30

--- a/src/dashboard_api.py
+++ b/src/dashboard_api.py
@@ -919,7 +919,14 @@ def api_get_settings():
     cfg = _read_dashboard_config()
     sync_cfg = cfg.get("sync", {})
     sync_enabled = sync_cfg.get("enabled", True) if isinstance(sync_cfg, dict) else True
-    return {"sync_enabled": sync_enabled, "log_level": get_log_level()}
+    mtime_threshold = cfg.get("mtime_active_threshold", 120)
+    if not isinstance(mtime_threshold, (int, float)) or mtime_threshold <= 0:
+        mtime_threshold = 120
+    return {
+        "sync_enabled": sync_enabled,
+        "log_level": get_log_level(),
+        "mtime_active_threshold": int(mtime_threshold),
+    }
 
 
 @app.put("/api/settings", response_model=SettingsResponse)
@@ -943,12 +950,27 @@ async def api_put_settings(request: Request):
                 cfg["logging"] = {}
             cfg["logging"]["level"] = level
 
+    if "mtime_active_threshold" in body:
+        try:
+            val = int(body["mtime_active_threshold"])
+            if val > 0:
+                cfg["mtime_active_threshold"] = val
+        except (TypeError, ValueError):
+            pass
+
     _write_dashboard_config(cfg)
     _reload_sync_folder()
 
     sync_cfg = cfg.get("sync", {})
     sync_enabled = sync_cfg.get("enabled", True) if isinstance(sync_cfg, dict) else True
-    return {"sync_enabled": sync_enabled, "log_level": get_log_level()}
+    mtime_threshold = cfg.get("mtime_active_threshold", 120)
+    if not isinstance(mtime_threshold, (int, float)) or mtime_threshold <= 0:
+        mtime_threshold = 120
+    return {
+        "sync_enabled": sync_enabled,
+        "log_level": get_log_level(),
+        "mtime_active_threshold": int(mtime_threshold),
+    }
 
 
 # ── PWA / static routes ─────────────────────────────────────────────────────

--- a/src/process_tracker.py
+++ b/src/process_tracker.py
@@ -15,6 +15,7 @@ import time
 from datetime import UTC, datetime
 
 from .constants import (
+    DASHBOARD_CONFIG_PATH,
     EVENT_STALENESS_THRESHOLD,
     EVENT_TAIL_BUFFER,
     MACOS_APP_NAMES,
@@ -22,6 +23,7 @@ from .constants import (
     MAX_ANCESTRY_DEPTH,
     MAX_DIAGNOSTICS_CHAIN,
     MAX_UNIX_PARENT_DEPTH,
+    MTIME_ACTIVE_THRESHOLD,
     OSASCRIPT_TIMEOUT,
     OUTPUT_TAIL_BUFFER,
     POWERSHELL_TIMEOUT,
@@ -685,6 +687,54 @@ def _populate_window_titles(sessions: dict[str, ProcessInfo]):
         logger.debug("Error populating window titles: %s", e)
 
 
+def _get_mtime_threshold() -> float:
+    """Read mtime_active_threshold from dashboard-config.json, fall back to constant."""
+    try:
+        if os.path.exists(DASHBOARD_CONFIG_PATH):
+            with open(DASHBOARD_CONFIG_PATH, encoding="utf-8") as f:
+                cfg = json.load(f)
+            val = cfg.get("mtime_active_threshold")
+            if isinstance(val, (int, float)) and val > 0:
+                return float(val)
+    except Exception:
+        pass
+    return MTIME_ACTIVE_THRESHOLD
+
+
+def _detect_mtime_active_sessions(
+    already_matched: dict[str, ProcessInfo],
+) -> dict[str, ProcessInfo]:
+    """Detect active sessions that have no matched process but recently-written events.
+
+    This covers VS Code integrated Copilot CLI sessions (producer: copilot-agent)
+    which run inside the extension host rather than spawning a standalone copilot.exe.
+    A session is considered active if its events.jsonl was modified within the
+    configured threshold (default: MTIME_ACTIVE_THRESHOLD seconds).
+
+    The threshold can be overridden in ~/.copilot/dashboard-config.json:
+        {"mtime_active_threshold": 180}
+    """
+    if not os.path.isdir(EVENTS_DIR):
+        return {}
+    threshold = _get_mtime_threshold()
+    now = time.time()
+    result: dict[str, ProcessInfo] = {}
+    try:
+        for sid in os.listdir(EVENTS_DIR):
+            if sid in already_matched:
+                continue
+            events_file = os.path.join(EVENTS_DIR, sid, "events.jsonl")
+            try:
+                mtime = os.path.getmtime(events_file)
+            except OSError:
+                continue
+            if now - mtime <= threshold:
+                result[sid] = ProcessInfo(pid=0, parent_pid=0)
+    except OSError as e:
+        logger.debug("Error scanning session-state for mtime: %s", e)
+    return result
+
+
 def get_running_sessions() -> dict[str, ProcessInfo]:
     """
     Find running copilot processes and extract session info.
@@ -702,6 +752,11 @@ def get_running_sessions() -> dict[str, ProcessInfo]:
                 sessions = _get_running_sessions_windows()
             else:
                 sessions = _get_running_sessions_unix()
+
+            # Detect sessions active by mtime (VS Code integrated sessions)
+            mtime_sessions = _detect_mtime_active_sessions(sessions)
+            sessions.update(mtime_sessions)
+
             # Enrich each session with state info
             for sid, info in sessions.items():
                 ss = _get_session_state(sid)

--- a/src/schemas.py
+++ b/src/schemas.py
@@ -153,3 +153,4 @@ class SettingsResponse(BaseModel):
 
     sync_enabled: bool = True
     log_level: str = "INFO"
+    mtime_active_threshold: int = 120

--- a/tests/test_process_tracker.py
+++ b/tests/test_process_tracker.py
@@ -11,8 +11,10 @@ import pytest
 from src.models import ProcessInfo, SessionState
 from src.process_tracker import (
     CREATE_NO_WINDOW,
+    _detect_mtime_active_sessions,
     _event_data_cache,
     _get_live_branch,
+    _get_mtime_threshold,
     _get_running_sessions_unix,
     _get_running_sessions_windows,
     _get_session_state,
@@ -1098,6 +1100,166 @@ class TestGetRunningSessions:
             result = get_running_sessions()
 
         assert "stale-sess" in result
+
+
+# ---------------------------------------------------------------------------
+# _detect_mtime_active_sessions
+# ---------------------------------------------------------------------------
+
+
+class TestDetectMtimeActiveSessions:
+    """Tests for mtime-based active session detection (VS Code integrated sessions)."""
+
+    def test_detects_recently_modified_session(self, tmp_path):
+        """A session with a recently-modified events.jsonl is detected as active."""
+        sid = "abc-recent-session"
+        session_dir = tmp_path / sid
+        session_dir.mkdir()
+        events_file = session_dir / "events.jsonl"
+        events_file.write_text('{"type":"session.start"}\n')
+
+        with patch("src.process_tracker.EVENTS_DIR", str(tmp_path)):
+            result = _detect_mtime_active_sessions({})
+
+        assert sid in result
+        assert result[sid].pid == 0
+
+    def test_ignores_stale_session(self, tmp_path):
+        """A session with an old events.jsonl is not detected."""
+        sid = "old-session"
+        session_dir = tmp_path / sid
+        session_dir.mkdir()
+        events_file = session_dir / "events.jsonl"
+        events_file.write_text('{"type":"session.start"}\n')
+        # Set mtime to 5 minutes ago
+        old_time = time.time() - 300
+        os.utime(events_file, (old_time, old_time))
+
+        with patch("src.process_tracker.EVENTS_DIR", str(tmp_path)):
+            result = _detect_mtime_active_sessions({})
+
+        assert sid not in result
+
+    def test_skips_already_matched_sessions(self, tmp_path):
+        """Sessions already matched to a process are not duplicated."""
+        sid = "already-matched"
+        session_dir = tmp_path / sid
+        session_dir.mkdir()
+        (session_dir / "events.jsonl").write_text('{"type":"session.start"}\n')
+
+        already = {sid: ProcessInfo(pid=1234)}
+        with patch("src.process_tracker.EVENTS_DIR", str(tmp_path)):
+            result = _detect_mtime_active_sessions(already)
+
+        assert sid not in result
+
+    def test_handles_missing_events_dir(self):
+        """Returns empty dict when session-state directory doesn't exist."""
+        with patch("src.process_tracker.EVENTS_DIR", "/nonexistent/path"):
+            result = _detect_mtime_active_sessions({})
+
+        assert result == {}
+
+    def test_skips_session_without_events_file(self, tmp_path):
+        """A session directory without events.jsonl is skipped."""
+        sid = "no-events"
+        (tmp_path / sid).mkdir()
+
+        with patch("src.process_tracker.EVENTS_DIR", str(tmp_path)):
+            result = _detect_mtime_active_sessions({})
+
+        assert sid not in result
+
+    def test_mtime_sessions_enriched_in_get_running_sessions(self, tmp_path):
+        """Mtime-detected sessions get state enrichment in get_running_sessions()."""
+        _running_cache.data = {}
+        _running_cache.time = 0.0
+
+        sid = "vscode-session"
+        session_dir = tmp_path / sid
+        session_dir.mkdir()
+        (session_dir / "events.jsonl").write_text('{"type":"assistant.turn_end"}\n')
+
+        state = SessionState(
+            state="idle", waiting_context="waiting", bg_tasks=0, bg_task_list=[]
+        )
+
+        with (
+            patch("src.process_tracker.sys.platform", "darwin"),
+            patch("src.process_tracker._get_running_sessions_unix", return_value={}),
+            patch("src.process_tracker.EVENTS_DIR", str(tmp_path)),
+            patch("src.process_tracker._get_session_state", return_value=state),
+        ):
+            result = get_running_sessions()
+
+        assert sid in result
+        assert result[sid].state == "idle"
+
+        # Cleanup
+        _running_cache.data = {}
+        _running_cache.time = 0.0
+
+
+class TestGetMtimeThreshold:
+    """Tests for _get_mtime_threshold() config override."""
+
+    def test_returns_default_when_no_config(self, tmp_path):
+        """Falls back to MTIME_ACTIVE_THRESHOLD when config doesn't exist."""
+        with patch("src.process_tracker.DASHBOARD_CONFIG_PATH", str(tmp_path / "nope.json")):
+            result = _get_mtime_threshold()
+        from src.constants import MTIME_ACTIVE_THRESHOLD
+
+        assert result == MTIME_ACTIVE_THRESHOLD
+
+    def test_reads_custom_value_from_config(self, tmp_path):
+        """Reads mtime_active_threshold from dashboard-config.json."""
+        cfg_file = tmp_path / "dashboard-config.json"
+        cfg_file.write_text('{"mtime_active_threshold": 300}')
+        with patch("src.process_tracker.DASHBOARD_CONFIG_PATH", str(cfg_file)):
+            result = _get_mtime_threshold()
+        assert result == 300.0
+
+    def test_ignores_invalid_value(self, tmp_path):
+        """Falls back to default when config value is invalid."""
+        cfg_file = tmp_path / "dashboard-config.json"
+        cfg_file.write_text('{"mtime_active_threshold": "not a number"}')
+        with patch("src.process_tracker.DASHBOARD_CONFIG_PATH", str(cfg_file)):
+            result = _get_mtime_threshold()
+        from src.constants import MTIME_ACTIVE_THRESHOLD
+
+        assert result == MTIME_ACTIVE_THRESHOLD
+
+    def test_ignores_zero_or_negative(self, tmp_path):
+        """Falls back to default when config value is zero or negative."""
+        cfg_file = tmp_path / "dashboard-config.json"
+        cfg_file.write_text('{"mtime_active_threshold": 0}')
+        with patch("src.process_tracker.DASHBOARD_CONFIG_PATH", str(cfg_file)):
+            result = _get_mtime_threshold()
+        from src.constants import MTIME_ACTIVE_THRESHOLD
+
+        assert result == MTIME_ACTIVE_THRESHOLD
+
+    def test_custom_threshold_used_in_detection(self, tmp_path):
+        """A session older than default but within custom threshold is detected."""
+        cfg_file = tmp_path / "config.json"
+        cfg_file.write_text('{"mtime_active_threshold": 600}')
+
+        sid = "custom-threshold-session"
+        session_dir = tmp_path / "sessions" / sid
+        session_dir.mkdir(parents=True)
+        events_file = session_dir / "events.jsonl"
+        events_file.write_text('{"type":"session.start"}\n')
+        # Set mtime to 200s ago (beyond default 120s, within custom 600s)
+        old_time = time.time() - 200
+        os.utime(events_file, (old_time, old_time))
+
+        with (
+            patch("src.process_tracker.EVENTS_DIR", str(tmp_path / "sessions")),
+            patch("src.process_tracker.DASHBOARD_CONFIG_PATH", str(cfg_file)),
+        ):
+            result = _detect_mtime_active_sessions({})
+
+        assert sid in result
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

This PR fixes two bugs and adds a configurable UI setting:

### 1. VS Code sessions never shown as Active (fixes #58)

VS Code's built-in Copilot CLI agent runs inside the extension host — no standalone `copilot.exe` process exists. Agent Eye's process-based detection never finds these sessions.

**Fix**: Add mtime-based fallback detection. After process matching, scan `session-state/` for any `events.jsonl` modified within a configurable threshold. These sessions get a synthetic `ProcessInfo(pid=0)` and receive full state enrichment (working/waiting/idle) from their event log.

### 2. Settings PUT requests fail with 401 (fixes #59)

The `put()` helper in `frontend/src/api/client.ts` was not calling `withToken(url)`, so all settings changes from the hamburger menu silently failed.

### 3. "Active timeout" setting in hamburger menu

Exposes the mtime threshold as a UI control (60s / 120s / 180s / 5min / 10min). Persisted to `~/.copilot/dashboard-config.json` as `mtime_active_threshold`.

## Changes

| File | Change |
|------|--------|
| `src/constants.py` | Add `MTIME_ACTIVE_THRESHOLD` (default 120s) |
| `src/process_tracker.py` | Add `_get_mtime_threshold()`, `_detect_mtime_active_sessions()` |
| `src/dashboard_api.py` | Expose threshold in GET/PUT `/api/settings` |
| `src/schemas.py` | Add `mtime_active_threshold` to `SettingsResponse` |
| `frontend/src/api/client.ts` | Fix: add `withToken()` to `put()` helper |
| `frontend/src/types/api.ts` | Add `mtime_active_threshold` to `DashboardSettings` |
| `frontend/src/hooks/useSettings.ts` | Add `setMtimeThreshold` |
| `frontend/src/components/HamburgerMenu.tsx` | Add "Active timeout" dropdown |
| `tests/test_process_tracker.py` | 11 new tests for mtime detection + config |

## Testing

- All 390 tests pass (1 pre-existing macOS-only failure on Windows)
- Manually verified: VS Code sessions now appear in Active tab
- Manually verified: settings changes persist after page refresh