### PR TITLE
Add browser-mode fallback for Windows ARM64

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -132,6 +132,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -524,6 +525,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -564,6 +566,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1792,8 +1795,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -1878,6 +1880,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1888,6 +1891,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -1927,6 +1931,7 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -2294,6 +2299,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2344,7 +2350,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2477,6 +2482,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2713,8 +2719,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.302",
@@ -2814,6 +2819,7 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3433,6 +3439,7 @@
       "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.31",
         "@asamuzakjp/dom-selector": "^6.8.1",
@@ -3590,7 +3597,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -3833,6 +3839,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3885,7 +3892,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -3901,7 +3907,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -3924,6 +3929,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -3936,6 +3942,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -3949,8 +3956,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -4298,6 +4304,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4363,6 +4370,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -4438,6 +4446,7 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -4644,6 +4653,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/src/components/SessionTile.tsx
+++ b/frontend/src/components/SessionTile.tsx
@@ -104,10 +104,10 @@ export default function SessionTile({ session: s, processInfo, onOpenDetail }: S
       )}
 
       {/* Waiting context */}
-      {isWaiting && processInfo!.waiting_context && (
-        <div className="tile-subtitle" style={{ color: "var(--yellow)" }} data-tip={`Waiting for: ${processInfo!.waiting_context}`}>
-          {processInfo!.waiting_context.substring(0, 80)}
-          {processInfo!.waiting_context.length > 80 ? "..." : ""}
+      {isWaiting && processInfo?.waiting_context && (
+        <div className="tile-subtitle" style={{ color: "var(--yellow)" }} data-tip={`Waiting for: ${processInfo.waiting_context}`}>
+          {processInfo.waiting_context.substring(0, 80)}
+          {processInfo.waiting_context.length > 80 ? "..." : ""}
         </div>
       )}
 

--- a/src/dashboard_api.py
+++ b/src/dashboard_api.py
@@ -87,6 +87,16 @@ STATIC_DIR = os.path.join(PKG_DIR, "static")
 DIST_DIR = os.path.join(STATIC_DIR, "dist")
 TEMPLATES_DIR = os.path.join(PKG_DIR, "templates")
 
+# How the running process was launched. Set by tray_app.run() before the
+# server thread starts; the autostart endpoint uses it to pick a matching
+# autostart command so a "Start at Login" toggle from the dashboard restarts
+# the app the same way the user is already using it.
+#   "app"     - tray app with embedded webview window
+#   "server"  - headless API server (no tray, no window). Also the right
+#               autostart target for the tray-app-in-browser-mode fallback,
+#               since there's no embedded window for the tray to host.
+LAUNCH_MODE: str = "server"
+
 DB_PATH = SESSION_STORE_DB
 _version_cache = VersionCache()
 _version_lock = threading.Lock()
@@ -833,22 +843,26 @@ def api_autostart_status():
 
 @app.post("/api/autostart/enable", response_model=ActionResponse)
 def api_autostart_enable(request: Request):
-    """Enable autostart via the Windows HKCU Run registry key."""
+    """Enable autostart via the Windows HKCU Run registry key.
+
+    Picks the autostart command based on how the running process was launched
+    (see ``LAUNCH_MODE``): "app" if started via ``agenteye app`` with a
+    working embedded webview, otherwise "server" (the lighter, headless
+    background mode, also the right target on platforms where the tray app
+    falls back to opening a browser).
+    """
     if sys.platform != "win32":
         return {"success": False, "message": "Autostart is only supported on Windows."}
 
-    import shutil
     import winreg
+
+    from .session_dashboard import _get_autostart_cmd_str
 
     scope = request.scope
     server = scope.get("server")
-    port = str(server[1]) if server and len(server) >= 2 else "5111"
+    port = int(server[1]) if server and len(server) >= 2 else 5111
 
-    cmd = shutil.which("agenteye")
-    if cmd:
-        cmd_str = f'"{cmd}" start --background --port {port}'
-    else:
-        cmd_str = f'"{sys.executable}" -m src.session_dashboard start --background --port {port}'
+    cmd_str = _get_autostart_cmd_str(port, mode=LAUNCH_MODE)
 
     try:
         with winreg.OpenKey(winreg.HKEY_CURRENT_USER, _RUN_KEY, 0, winreg.KEY_SET_VALUE) as key:

--- a/src/tray_app.py
+++ b/src/tray_app.py
@@ -8,6 +8,8 @@ The server runs in-process and stays alive as long as the tray app is running.
 from __future__ import annotations
 
 import ctypes
+import os
+import shutil
 import sys
 import threading
 from pathlib import Path
@@ -39,6 +41,31 @@ else:
     _HAS_APPKIT = False
     NSApplication = None  # type: ignore[misc, assignment]
     NSImage = None  # type: ignore[misc, assignment]
+
+
+def _pywebview_supported() -> bool:
+    """Return False when pywebview is known to be unusable on this platform.
+
+    The WinForms backend that pywebview uses on Windows depends on pythonnet
+    successfully reflecting over `System.Windows.Forms` and several private
+    internal types (`FileDialogNative+IFileDialog`, etc.) that were removed in
+    .NET Core+. On x64 Windows pythonnet loads `netfx` (the .NET Framework
+    GAC), where those types still exist, so everything works. On ARM64 Windows
+    .NET Framework does not exist at all, pythonnet falls back to coreclr, and
+    pywebview's WinForms backend cannot initialize. See pywebview PR #1803.
+
+    Until that is fixed upstream, fall back to opening the dashboard in the
+    user's default browser. Override with `AGENTEYE_BROWSER_MODE=1` to force
+    browser mode on other platforms (useful for headless / SSH scenarios).
+    """
+    import os
+    import platform
+
+    if os.environ.get("AGENTEYE_BROWSER_MODE", "").lower() in ("1", "true", "yes"):
+        return False
+    if sys.platform == "win32" and platform.machine().lower() in ("arm64", "aarch64"):
+        return False
+    return True
 
 
 def _set_dark_title_bar(hwnd: int, dark: bool = True) -> None:
@@ -267,6 +294,11 @@ class TrayApp:
         self._server_started = threading.Event()
         self._shutdown_requested = False
         self._webview_module: Any = None
+        self.browser_mode: bool = not _pywebview_supported()
+        # Process handle for the Edge/Chrome --app=URL window used in
+        # browser_mode, so the tray "Show Dashboard" action can avoid spawning
+        # a duplicate window when one is already open.
+        self._app_window_proc: Any = None
 
     def _start_server(self) -> None:
         """Start the FastAPI server in a background thread."""
@@ -339,6 +371,9 @@ class TrayApp:
 
     def _toggle_window(self) -> None:
         """Toggle window visibility (show if hidden, hide if shown)."""
+        if self.browser_mode:
+            self._show_window()
+            return
         if not self.window:
             return
         # pywebview doesn't expose visibility state, so we just show
@@ -346,6 +381,13 @@ class TrayApp:
 
     def _show_window(self) -> None:
         """Show and focus the dashboard window."""
+        if self.browser_mode:
+            # No native window in browser mode — open in a Chromium app-mode
+            # (frameless) window when possible to mimic the embedded webview
+            # experience, falling back to a regular browser tab otherwise.
+            if not self._open_in_app_window():
+                self._open_in_browser()
+            return
         if self.window:
             _set_macos_dock_visible(True)  # Restore dock icon when window is shown
             # Re-assert our custom dock icon: when the app started hidden the icon
@@ -372,6 +414,95 @@ class TrayApp:
 
         webbrowser.open(f"http://127.0.0.1:{self.port}")
 
+    def _open_in_app_window(self) -> bool:
+        """Open the dashboard in a Chromium app-mode (frameless) window.
+
+        Uses Edge or Chrome's ``--app=URL`` with a dedicated user-data-dir so
+        the window opens standalone instead of joining the user's normal
+        browsing session. Returns True if an app window was successfully
+        spawned (or one is already alive); False if no suitable browser was
+        found and the caller should fall back to a regular browser tab.
+        """
+        import subprocess
+
+        # If a previously spawned app window is still alive, do nothing -
+        # bringing it to front from outside the process is non-trivial and a
+        # second --app launch would just open a second window.
+        if self._app_window_proc is not None and self._app_window_proc.poll() is None:
+            return True
+
+        browser_path = self._find_chromium_browser()
+        if not browser_path:
+            return False
+
+        url = f"http://127.0.0.1:{self.port}"
+        # --guest gives an ephemeral session: no sign-in, no sync, no profile
+        # persistence. Avoids Edge's Windows-SSO auto-enrolling the profile
+        # into the user's work account. Theme/localStorage are lost between
+        # launches, but for a local dashboard that's an acceptable trade.
+        cmd = [
+            browser_path,
+            "--guest",
+            f"--app={url}",
+            "--window-size=1200,800",
+            "--no-first-run",
+            "--no-default-browser-check",
+        ]
+
+        kwargs: dict = {
+            "stdout": subprocess.DEVNULL,
+            "stderr": subprocess.DEVNULL,
+        }
+        if sys.platform == "win32":
+            # DETACHED_PROCESS | CREATE_NO_WINDOW so the browser survives
+            # independently and we don't flash a console.
+            kwargs["creationflags"] = 0x00000008 | subprocess.CREATE_NO_WINDOW
+        else:
+            kwargs["start_new_session"] = True
+
+        try:
+            self._app_window_proc = subprocess.Popen(cmd, **kwargs)
+            return True
+        except Exception:
+            self._app_window_proc = None
+            return False
+
+    @staticmethod
+    def _find_chromium_browser() -> str | None:
+        """Locate a Chromium-based browser executable for ``--app`` mode.
+
+        Prefers Edge (always present on modern Windows), then Chrome, then
+        Brave. Returns None on platforms / installs without one.
+        """
+        candidates: list[str] = []
+        if sys.platform == "win32":
+            pf = os.environ.get("ProgramFiles", r"C:\Program Files")
+            pf86 = os.environ.get("ProgramFiles(x86)", r"C:\Program Files (x86)")
+            local = os.environ.get("LOCALAPPDATA", "")
+            candidates = [
+                rf"{pf}\Microsoft\Edge\Application\msedge.exe",
+                rf"{pf86}\Microsoft\Edge\Application\msedge.exe",
+                rf"{pf}\Google\Chrome\Application\chrome.exe",
+                rf"{pf86}\Google\Chrome\Application\chrome.exe",
+                rf"{local}\Google\Chrome\Application\chrome.exe",
+                rf"{local}\Microsoft\Edge\Application\msedge.exe",
+            ]
+        elif sys.platform == "darwin":
+            candidates = [
+                "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
+                "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+                "/Applications/Brave Browser.app/Contents/MacOS/Brave Browser",
+            ]
+        else:
+            for name in ("microsoft-edge", "google-chrome", "chromium", "brave-browser"):
+                found = shutil.which(name)
+                if found:
+                    return found
+        for c in candidates:
+            if c and os.path.exists(c):
+                return c
+        return None
+
     def _quit(self) -> None:
         """Quit the application completely."""
         import os
@@ -382,6 +513,13 @@ class TrayApp:
         if self.window:
             try:
                 self.window.hide()
+            except Exception:
+                pass
+
+        # Close the Chromium app-mode window if we spawned one (browser_mode).
+        if self._app_window_proc is not None and self._app_window_proc.poll() is None:
+            try:
+                self._app_window_proc.terminate()
             except Exception:
                 pass
 
@@ -497,8 +635,95 @@ class TrayApp:
         assert self.tray_icon is not None
         self.tray_icon.run()
 
+    def _run_browser_mode(self) -> None:
+        """Run as a tray-only app, opening the dashboard in the default browser.
+
+        Used on platforms where pywebview's WinForms backend can't initialize
+        (currently: Windows ARM64; see _pywebview_supported). The local server
+        still runs in this process; the tray icon keeps it alive and exposes
+        the same menu (Show Dashboard, Open in Browser, Start at Login, Quit).
+        """
+        # Tell the API which autostart mode best matches how we're running.
+        # In browser_mode the embedded webview is unavailable, so autostart
+        # should use the lighter headless "server" command - matching what
+        # the user expects when they toggle "Start at Login" from the page.
+        try:
+            from . import dashboard_api
+
+            dashboard_api.LAUNCH_MODE = "server"
+        except Exception:
+            pass
+
+        # Windows-specific identity setup, same as the webview path.
+        if sys.platform == "win32":
+            app_id = "CopilotDashboard.App.1"
+            try:
+                ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(app_id)
+            except Exception:
+                pass
+            try:
+                import winreg
+
+                key_path = rf"SOFTWARE\Classes\AppUserModelId\{app_id}"
+                with winreg.CreateKey(winreg.HKEY_CURRENT_USER, key_path) as key:
+                    winreg.SetValueEx(key, "DisplayName", 0, winreg.REG_SZ, "Agent Eye")
+                    icon_path = _get_window_icon_path()
+                    if icon_path.exists():
+                        winreg.SetValueEx(key, "IconUri", 0, winreg.REG_SZ, str(icon_path))
+            except Exception:
+                pass
+
+        from .__version__ import __version__
+
+        print(f"  Agent Eye v{__version__} (Tray App, browser mode)")
+        print(f"  Starting on http://127.0.0.1:{self.port}")
+        print()
+        print("  Embedded webview is not available on this platform.")
+        print("  The dashboard will open in your default browser.")
+        print("  - Right-click tray icon -> Show Dashboard = re-open in browser")
+        print("  - Right-click tray icon -> Quit = exit completely")
+        print()
+
+        # Start the server in a background thread.
+        self.server_thread = threading.Thread(target=self._start_server, daemon=True)
+        self.server_thread.start()
+        self._server_started.wait(timeout=5)
+        self._wait_for_server(timeout=20.0)
+
+        print("  Dashboard ready!")
+
+        # Open the dashboard in a Chromium app-mode window (frameless,
+        # no toolbars - looks like a native app) unless start_hidden. Falls
+        # back to a regular browser tab if no Chromium-based browser is found.
+        if not self.start_hidden:
+            if not self._open_in_app_window():
+                self._open_in_browser()
+        else:
+            print("  (Started hidden - click tray icon to open the dashboard)")
+
+        # Build and run the tray icon (blocking until Quit).
+        self._build_tray_icon()
+        assert self.tray_icon is not None
+        self.tray_icon.run()
+
+        self._shutdown_requested = True
+
     def run(self) -> None:
         """Run the tray application."""
+        if self.browser_mode:
+            self._run_browser_mode()
+            return
+
+        # Tray-with-embedded-webview mode: tell the API which autostart command
+        # matches this launch so the dashboard's "Start at Login" toggle
+        # restarts the same way.
+        try:
+            from . import dashboard_api
+
+            dashboard_api.LAUNCH_MODE = "app"
+        except Exception:
+            pass
+
         import webview
 
         # Set the dock/menu-bar app name on macOS (otherwise shows "Python")

--- a/tests/test_tray_app.py
+++ b/tests/test_tray_app.py
@@ -6,7 +6,6 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-
 # ---------------------------------------------------------------------------
 # WindowApi tests
 # ---------------------------------------------------------------------------
@@ -416,3 +415,420 @@ class TestWaitForServer:
             patch("urllib.request.urlopen", side_effect=OSError("refused")),
         ):
             assert app._wait_for_server(timeout=1.0) is False
+
+
+# ---------------------------------------------------------------------------
+# Browser-mode fallback (for platforms where pywebview can't load, e.g. ARM64
+# Windows where pythonnet can't reflect over .NET 8+ WinForms types)
+# ---------------------------------------------------------------------------
+
+
+class TestPyWebViewSupported:
+    """Tests for _pywebview_supported() platform detection."""
+
+    @patch("sys.platform", "win32")
+    @patch("platform.machine", return_value="ARM64")
+    def test_windows_arm64_unsupported(self, _machine):
+        from src.tray_app import _pywebview_supported
+
+        with patch.dict("os.environ", {}, clear=False):
+            import os
+
+            os.environ.pop("AGENTEYE_BROWSER_MODE", None)
+            assert _pywebview_supported() is False
+
+    @patch("sys.platform", "win32")
+    @patch("platform.machine", return_value="AMD64")
+    def test_windows_x64_supported(self, _machine):
+        import os
+
+        from src.tray_app import _pywebview_supported
+
+        os.environ.pop("AGENTEYE_BROWSER_MODE", None)
+        assert _pywebview_supported() is True
+
+    @patch("sys.platform", "darwin")
+    @patch("platform.machine", return_value="arm64")
+    def test_macos_arm64_supported(self, _machine):
+        """macOS ARM64 doesn't use pythonnet/WinForms, so pywebview works."""
+        import os
+
+        from src.tray_app import _pywebview_supported
+
+        os.environ.pop("AGENTEYE_BROWSER_MODE", None)
+        assert _pywebview_supported() is True
+
+    @patch("sys.platform", "linux")
+    @patch("platform.machine", return_value="aarch64")
+    def test_linux_arm64_supported(self, _machine):
+        """Linux ARM64 doesn't use the WinForms backend."""
+        import os
+
+        from src.tray_app import _pywebview_supported
+
+        os.environ.pop("AGENTEYE_BROWSER_MODE", None)
+        assert _pywebview_supported() is True
+
+    @patch("sys.platform", "win32")
+    @patch("platform.machine", return_value="AMD64")
+    def test_env_override_forces_browser_mode(self, _machine):
+        """AGENTEYE_BROWSER_MODE=1 should force browser fallback even on x64."""
+        from src.tray_app import _pywebview_supported
+
+        with patch.dict("os.environ", {"AGENTEYE_BROWSER_MODE": "1"}):
+            assert _pywebview_supported() is False
+
+    @patch("sys.platform", "win32")
+    @patch("platform.machine", return_value="AMD64")
+    def test_env_override_accepts_truthy_variants(self, _machine):
+        from src.tray_app import _pywebview_supported
+
+        for val in ("1", "true", "TRUE", "yes", "YES"):
+            with patch.dict("os.environ", {"AGENTEYE_BROWSER_MODE": val}):
+                assert _pywebview_supported() is False, f"value {val!r} should trigger fallback"
+
+    @patch("sys.platform", "win32")
+    @patch("platform.machine", return_value="AMD64")
+    def test_env_override_ignores_falsy_variants(self, _machine):
+        from src.tray_app import _pywebview_supported
+
+        for val in ("0", "false", "no", ""):
+            with patch.dict("os.environ", {"AGENTEYE_BROWSER_MODE": val}):
+                assert _pywebview_supported() is True, f"value {val!r} should not trigger fallback"
+
+
+class TestTrayAppBrowserMode:
+    """Tests for TrayApp browser-mode initialization and behavior."""
+
+    def test_init_sets_browser_mode_from_probe(self):
+        from src.tray_app import TrayApp
+
+        with patch("src.tray_app._pywebview_supported", return_value=False):
+            app = TrayApp()
+            assert app.browser_mode is True
+
+        with patch("src.tray_app._pywebview_supported", return_value=True):
+            app = TrayApp()
+            assert app.browser_mode is False
+
+    def test_init_creates_app_window_proc_slot(self):
+        from src.tray_app import TrayApp
+
+        app = TrayApp()
+        assert app._app_window_proc is None
+
+    def test_show_window_in_browser_mode_uses_app_window(self):
+        """In browser_mode, _show_window should prefer the Chromium app window."""
+        from src.tray_app import TrayApp
+
+        with patch("src.tray_app._pywebview_supported", return_value=False):
+            app = TrayApp()
+        app._open_in_app_window = MagicMock(return_value=True)  # type: ignore[method-assign]
+        app._open_in_browser = MagicMock()  # type: ignore[method-assign]
+        app._show_window()
+        app._open_in_app_window.assert_called_once()
+        app._open_in_browser.assert_not_called()
+
+    def test_show_window_falls_back_to_browser_when_no_chromium(self):
+        from src.tray_app import TrayApp
+
+        with patch("src.tray_app._pywebview_supported", return_value=False):
+            app = TrayApp()
+        app._open_in_app_window = MagicMock(return_value=False)  # type: ignore[method-assign]
+        app._open_in_browser = MagicMock()  # type: ignore[method-assign]
+        app._show_window()
+        app._open_in_app_window.assert_called_once()
+        app._open_in_browser.assert_called_once()
+
+    def test_show_window_in_webview_mode_does_not_open_browser(self):
+        """When pywebview is supported, _show_window should not touch browser code paths."""
+        from src.tray_app import TrayApp
+
+        with patch("src.tray_app._pywebview_supported", return_value=True):
+            app = TrayApp()
+        app._open_in_app_window = MagicMock()  # type: ignore[method-assign]
+        app._open_in_browser = MagicMock()  # type: ignore[method-assign]
+        # window is None -> early return path; ensures browser methods aren't called
+        app._show_window()
+        app._open_in_app_window.assert_not_called()
+        app._open_in_browser.assert_not_called()
+
+
+class TestFindChromiumBrowser:
+    """Tests for TrayApp._find_chromium_browser()."""
+
+    @patch("sys.platform", "win32")
+    def test_returns_edge_when_present(self):
+        from src.tray_app import TrayApp
+
+        edge = r"C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe"
+        with (
+            patch.dict(
+                "os.environ",
+                {
+                    "ProgramFiles": r"C:\Program Files",
+                    "ProgramFiles(x86)": r"C:\Program Files (x86)",
+                },
+            ),
+            patch("os.path.exists", side_effect=lambda p: p == edge),
+        ):
+            assert TrayApp._find_chromium_browser() == edge
+
+    @patch("sys.platform", "win32")
+    def test_returns_chrome_when_edge_missing(self):
+        from src.tray_app import TrayApp
+
+        chrome = r"C:\Program Files\Google\Chrome\Application\chrome.exe"
+        with (
+            patch.dict(
+                "os.environ",
+                {
+                    "ProgramFiles": r"C:\Program Files",
+                    "ProgramFiles(x86)": r"C:\Program Files (x86)",
+                },
+            ),
+            patch("os.path.exists", side_effect=lambda p: p == chrome),
+        ):
+            assert TrayApp._find_chromium_browser() == chrome
+
+    @patch("sys.platform", "win32")
+    def test_returns_none_when_no_browser_found(self):
+        from src.tray_app import TrayApp
+
+        with (
+            patch.dict(
+                "os.environ",
+                {
+                    "ProgramFiles": r"C:\Program Files",
+                    "ProgramFiles(x86)": r"C:\Program Files (x86)",
+                },
+            ),
+            patch("os.path.exists", return_value=False),
+        ):
+            assert TrayApp._find_chromium_browser() is None
+
+    @patch("sys.platform", "linux")
+    def test_linux_uses_path_lookup(self):
+        from src.tray_app import TrayApp
+
+        with patch(
+            "shutil.which",
+            side_effect=lambda name: "/usr/bin/google-chrome" if name == "google-chrome" else None,
+        ):
+            assert TrayApp._find_chromium_browser() == "/usr/bin/google-chrome"
+
+
+class TestOpenInAppWindow:
+    """Tests for TrayApp._open_in_app_window() spawning."""
+
+    def test_returns_false_when_no_browser_found(self):
+        from src.tray_app import TrayApp
+
+        app = TrayApp(port=5111)
+        with patch.object(TrayApp, "_find_chromium_browser", return_value=None):
+            assert app._open_in_app_window() is False
+        assert app._app_window_proc is None
+
+    def test_spawns_browser_with_guest_and_app_flags(self):
+        """The command line should include --guest, --app=URL, and sane defaults."""
+        from src.tray_app import TrayApp
+
+        app = TrayApp(port=5111)
+        fake_proc = MagicMock()
+        fake_proc.poll.return_value = None
+
+        with (
+            patch.object(TrayApp, "_find_chromium_browser", return_value="msedge.exe"),
+            patch("subprocess.Popen", return_value=fake_proc) as mock_popen,
+        ):
+            assert app._open_in_app_window() is True
+
+        args = mock_popen.call_args.args[0]
+        assert args[0] == "msedge.exe"
+        assert "--guest" in args
+        assert "--app=http://127.0.0.1:5111" in args
+        # No persistent profile dir flag: --guest gives an ephemeral session
+        # that avoids Windows-SSO auto-enrollment of a fresh Edge profile.
+        assert not any(a.startswith("--user-data-dir=") for a in args)
+        assert app._app_window_proc is fake_proc
+
+    def test_does_not_relaunch_when_window_alive(self):
+        """If a previous app window is still running, do not spawn a duplicate."""
+        from src.tray_app import TrayApp
+
+        app = TrayApp(port=5111)
+        alive_proc = MagicMock()
+        alive_proc.poll.return_value = None  # still running
+        app._app_window_proc = alive_proc
+
+        with (
+            patch.object(TrayApp, "_find_chromium_browser", return_value="msedge.exe"),
+            patch("subprocess.Popen") as mock_popen,
+        ):
+            assert app._open_in_app_window() is True
+            mock_popen.assert_not_called()
+
+    def test_relaunches_when_window_exited(self):
+        """If the previous window subprocess has exited, spawn a new one."""
+        from src.tray_app import TrayApp
+
+        app = TrayApp(port=5111)
+        dead_proc = MagicMock()
+        dead_proc.poll.return_value = 0  # exited
+        app._app_window_proc = dead_proc
+
+        new_proc = MagicMock()
+        new_proc.poll.return_value = None
+
+        with (
+            patch.object(TrayApp, "_find_chromium_browser", return_value="msedge.exe"),
+            patch("subprocess.Popen", return_value=new_proc) as mock_popen,
+        ):
+            assert app._open_in_app_window() is True
+            mock_popen.assert_called_once()
+            assert app._app_window_proc is new_proc
+
+    def test_returns_false_on_popen_failure(self):
+        from src.tray_app import TrayApp
+
+        app = TrayApp(port=5111)
+        with (
+            patch.object(TrayApp, "_find_chromium_browser", return_value="msedge.exe"),
+            patch("subprocess.Popen", side_effect=OSError("nope")),
+        ):
+            assert app._open_in_app_window() is False
+        assert app._app_window_proc is None
+
+
+class TestQuitCleansUpAppWindow:
+    """Tests for TrayApp._quit() terminating the spawned Chromium window."""
+
+    def test_quit_terminates_alive_app_window(self):
+        from src.tray_app import TrayApp
+
+        app = TrayApp()
+        proc = MagicMock()
+        proc.poll.return_value = None  # still running
+        app._app_window_proc = proc
+
+        with patch("os._exit") as mock_exit:
+            app._quit()
+
+        proc.terminate.assert_called_once()
+        mock_exit.assert_called_once_with(0)
+
+    def test_quit_does_not_terminate_exited_app_window(self):
+        from src.tray_app import TrayApp
+
+        app = TrayApp()
+        proc = MagicMock()
+        proc.poll.return_value = 0  # already exited
+        app._app_window_proc = proc
+
+        with patch("os._exit"):
+            app._quit()
+
+        proc.terminate.assert_not_called()
+
+    def test_quit_with_no_app_window_does_not_crash(self):
+        from src.tray_app import TrayApp
+
+        app = TrayApp()
+        assert app._app_window_proc is None
+        with patch("os._exit") as mock_exit:
+            app._quit()
+        mock_exit.assert_called_once_with(0)
+
+
+class TestRunBrowserMode:
+    """Tests for TrayApp._run_browser_mode() flow."""
+
+    def test_browser_mode_starts_server_and_tray(self):
+        """_run_browser_mode should start the server thread, wait, open the
+        dashboard, and block on tray_icon.run()."""
+        from src.tray_app import TrayApp
+
+        with patch("src.tray_app._pywebview_supported", return_value=False):
+            app = TrayApp(port=5111)
+
+        tray_icon = MagicMock()
+
+        # Substitute methods on the *instance* so we don't actually start a
+        # uvicorn server, open a real browser, or block on a real tray loop.
+        app._start_server = MagicMock()  # type: ignore[method-assign]
+        app._wait_for_server = MagicMock(return_value=True)  # type: ignore[method-assign]
+        app._open_in_app_window = MagicMock(return_value=True)  # type: ignore[method-assign]
+        app._open_in_browser = MagicMock()  # type: ignore[method-assign]
+        app._build_tray_icon = MagicMock(  # type: ignore[method-assign]
+            side_effect=lambda: setattr(app, "tray_icon", tray_icon)
+        )
+
+        with patch("threading.Thread") as mock_thread:
+            # The Thread we create for the server doesn't actually need to
+            # run anything because _start_server is mocked.
+            mock_thread.return_value.start = MagicMock()
+            app._run_browser_mode()
+
+        app._wait_for_server.assert_called_once()
+        app._open_in_app_window.assert_called_once()
+        app._open_in_browser.assert_not_called()
+        tray_icon.run.assert_called_once()
+        assert app._shutdown_requested is True
+
+    def test_browser_mode_hidden_skips_opening_window(self):
+        from src.tray_app import TrayApp
+
+        with patch("src.tray_app._pywebview_supported", return_value=False):
+            app = TrayApp(port=5111, start_hidden=True)
+
+        tray_icon = MagicMock()
+        app._start_server = MagicMock()  # type: ignore[method-assign]
+        app._wait_for_server = MagicMock(return_value=True)  # type: ignore[method-assign]
+        app._open_in_app_window = MagicMock(return_value=True)  # type: ignore[method-assign]
+        app._open_in_browser = MagicMock()  # type: ignore[method-assign]
+        app._build_tray_icon = MagicMock(  # type: ignore[method-assign]
+            side_effect=lambda: setattr(app, "tray_icon", tray_icon)
+        )
+
+        with patch("threading.Thread"):
+            app._run_browser_mode()
+
+        app._open_in_app_window.assert_not_called()
+        app._open_in_browser.assert_not_called()
+        tray_icon.run.assert_called_once()
+
+    def test_browser_mode_falls_back_to_default_browser(self):
+        from src.tray_app import TrayApp
+
+        with patch("src.tray_app._pywebview_supported", return_value=False):
+            app = TrayApp(port=5111)
+
+        tray_icon = MagicMock()
+        app._start_server = MagicMock()  # type: ignore[method-assign]
+        app._wait_for_server = MagicMock(return_value=True)  # type: ignore[method-assign]
+        app._open_in_app_window = MagicMock(return_value=False)  # type: ignore[method-assign]
+        app._open_in_browser = MagicMock()  # type: ignore[method-assign]
+        app._build_tray_icon = MagicMock(  # type: ignore[method-assign]
+            side_effect=lambda: setattr(app, "tray_icon", tray_icon)
+        )
+
+        with patch("threading.Thread"):
+            app._run_browser_mode()
+
+        app._open_in_app_window.assert_called_once()
+        app._open_in_browser.assert_called_once()
+
+    def test_run_dispatches_to_browser_mode_when_unsupported(self):
+        """TrayApp.run() should hand off to _run_browser_mode without ever
+        importing pywebview when browser_mode is set."""
+        from src.tray_app import TrayApp
+
+        with patch("src.tray_app._pywebview_supported", return_value=False):
+            app = TrayApp(port=5111)
+        app._run_browser_mode = MagicMock()  # type: ignore[method-assign]
+
+        # If run() tried to import webview, it would blow up on this machine
+        # (ARM64). The fact that the call returns cleanly confirms the
+        # browser_mode branch short-circuits before the pywebview import.
+        app.run()
+        app._run_browser_mode.assert_called_once()


### PR DESCRIPTION
## What

On Windows ARM64, `agenteye app` fails to start because pywebview''s WinForms backend can''t initialize:

- pythonnet defaults to the `netfx` loader, which doesn''t exist on ARM64.
- Forced onto `coreclr`, reflection over .NET 8/9 `System.Windows.Forms` hits `TypeLoadException` for legacy types (e.g. `ContextMenu`).
- pywebview''s `OpenFolderDialog` reflects into private internal types removed in modern .NET.

Upstream fix is in flight at [pywebview PR #1803](https://github.com/r0x0r/pywebview/pull/1803) but stalled. Tracking issue for restoring the real embedded webview: #61.

## How

Adds a runtime probe (`_pywebview_supported`) and a tray-mode fallback:

- Detects Windows ARM64 (or honors `AGENTEYE_BROWSER_MODE=1`) and switches to browser-mode.
- Local server still runs in-process; pystray icon stays resident with the same menu.
- "Show Dashboard" spawns Edge (then Chrome, Brave) as `--guest --app=URL` -> frameless, ephemeral, sign-in-free window. Falls back to `webbrowser.open()` if no Chromium browser is found.
- Quit cleans up the spawned browser process.
- Wires a new `LAUNCH_MODE` through `dashboard_api` so the dashboard''s "Start at Login" toggle picks an autostart command that matches how the app is currently running (`app` for the normal tray-webview path, `server` for browser-mode).
- Fixes a `SessionTile.tsx` crash on remote sessions in `waiting` state where `processInfo` is undefined.

## Tests

- 28 new `tray_app` tests covering the probe, browser detection, `--guest`/`--app` spawn, idempotent relaunch, quit-time cleanup, and `run()` dispatch.
- All 58 `tray_app` tests pass; `ruff` and `mypy` clean for changed files.
- Manually verified on Windows 11 ARM64 + Python 3.14 ARM64: tray launches, Edge app window opens, Quit terminates everything cleanly.

Tracking real fix: #61