### PR TITLE
fix: read Claude session cwd from transcript instead of lossy dir-name decoding

### DIFF
--- a/src/claude_code.py
+++ b/src/claude_code.py
@@ -85,7 +85,43 @@ def _decode_project_dir(dir_name: str) -> str:
         if len(dir_name) >= 3 and dir_name[1:3] == "--":
             return dir_name[0] + ":\\" + dir_name[3:].replace("-", "\\")
         return dir_name.replace("-", "\\")
-    return "/" + dir_name.replace("-", "/")
+    # Absolute paths encode their leading "/" as a leading dash
+    return "/" + dir_name.removeprefix("-").replace("-", "/")
+
+
+# Encoded-dir decoding is lossy (real hyphens/dots in path segments are
+# indistinguishable from separators), so prefer the exact ``cwd`` recorded
+# on transcript event lines. Cache hits by path: a session's cwd is fixed.
+_transcript_cwd_cache: dict[str, str] = {}
+
+# Not every line carries ``cwd``, but it appears within the first few events
+# of any real session; the cap keeps degenerate files from being read fully.
+_CWD_SCAN_MAX_LINES = 200
+
+
+def _cwd_from_transcript(jsonl_path: str) -> str | None:
+    """Return the working directory recorded in a session transcript."""
+    cached = _transcript_cwd_cache.get(jsonl_path)
+    if cached:
+        return cached
+    try:
+        with open(jsonl_path, encoding="utf-8", errors="replace") as f:
+            for i, line_str in enumerate(f):
+                if i >= _CWD_SCAN_MAX_LINES:
+                    break
+                if '"cwd"' not in line_str:
+                    continue
+                try:
+                    msg = json.loads(line_str)
+                except json.JSONDecodeError:
+                    continue
+                cwd = msg.get("cwd")
+                if isinstance(cwd, str) and cwd:
+                    _transcript_cwd_cache[jsonl_path] = cwd
+                    return cwd
+    except OSError:
+        pass
+    return None
 
 
 def _session_from_transcript(
@@ -105,6 +141,7 @@ def _session_from_transcript(
     message_count = 0
     created_ts = ""
     modified_ts = ""
+    recorded_cwd = ""
     try:
         with open(jsonl_path, encoding="utf-8") as f:
             for line_str in f:
@@ -115,6 +152,10 @@ def _session_from_transcript(
                     msg = json.loads(line_str)
                 except json.JSONDecodeError:
                     continue
+                if not recorded_cwd:
+                    cwd_val = msg.get("cwd")
+                    if isinstance(cwd_val, str) and cwd_val:
+                        recorded_cwd = cwd_val
                 role = msg.get("type") or msg.get("role", "")
                 if role in ("user", "assistant"):
                     message_count += 1
@@ -134,6 +175,9 @@ def _session_from_transcript(
         created_ts = datetime.fromtimestamp(stat.st_ctime, tz=UTC).isoformat()
     if not modified_ts:
         modified_ts = datetime.fromtimestamp(stat.st_mtime, tz=UTC).isoformat()
+    if recorded_cwd:
+        _transcript_cwd_cache[jsonl_path] = recorded_cwd
+        project_cwd = recorded_cwd
 
     prefixed_id = SESSION_ID_PREFIX + sid
     s: dict = {
@@ -227,7 +271,11 @@ def get_claude_sessions(
 
                 created = entry.get("created", "")
                 modified = entry.get("modified", "") or created
-                cwd = entry.get("projectPath", "") or project_cwd
+                cwd = (
+                    entry.get("projectPath", "")
+                    or _cwd_from_transcript(os.path.join(project_path, f"{sid}.jsonl"))
+                    or project_cwd
+                )
 
                 s: dict = {
                     "id": prefixed_id,
@@ -403,7 +451,9 @@ def get_claude_session_cwd(session_id: str) -> str | None:
     transcript = _find_transcript(session_id)
     if not transcript:
         return None
-    return _decode_project_dir(os.path.basename(os.path.dirname(transcript)))
+    return _cwd_from_transcript(transcript) or _decode_project_dir(
+        os.path.basename(os.path.dirname(transcript))
+    )
 
 
 def _extract_text_from_content(content) -> str:

--- a/tests/test_claude_code.py
+++ b/tests/test_claude_code.py
@@ -10,6 +10,7 @@ from src.claude_code import (
     CREATE_NO_WINDOW,
     SESSION_ID_PREFIX,
     _build_restart_cmd,
+    _cwd_from_transcript,
     _decode_project_dir,
     _extract_first_prompt_text,
     _extract_session_id_from_cmdline,
@@ -17,6 +18,7 @@ from src.claude_code import (
     _extract_tool_uses,
     _find_transcript,
     _session_from_transcript,
+    get_claude_session_cwd,
     get_claude_session_detail,
     get_claude_sessions,
 )
@@ -324,6 +326,63 @@ class TestDecodeProjectDir:
         assert result == "/home/user/projects/myapp"
 
 
+# ── _cwd_from_transcript / get_claude_session_cwd ────────────────────────────
+
+
+class TestCwdFromTranscript:
+    def test_reads_recorded_cwd(self, tmp_path):
+        transcript = tmp_path / "sess.jsonl"
+        transcript.write_text(
+            "\n".join(
+                [
+                    json.dumps({"type": "queue", "sessionId": "sess"}),
+                    json.dumps(
+                        {
+                            "type": "user",
+                            "cwd": "/home/user/my-hyphen.project",
+                            "message": {"role": "user", "content": "hi"},
+                        }
+                    ),
+                ]
+            ),
+            encoding="utf-8",
+        )
+        assert _cwd_from_transcript(str(transcript)) == "/home/user/my-hyphen.project"
+
+    def test_returns_none_without_cwd(self, tmp_path):
+        transcript = tmp_path / "sess.jsonl"
+        transcript.write_text(json.dumps({"type": "user"}), encoding="utf-8")
+        assert _cwd_from_transcript(str(transcript)) is None
+
+    def test_returns_none_for_missing_file(self, tmp_path):
+        assert _cwd_from_transcript(str(tmp_path / "nope.jsonl")) is None
+
+    def test_session_cwd_prefers_transcript_over_decoded_name(self, tmp_path):
+        """Hyphens in real paths survive: transcript cwd wins over lossy decoding."""
+        projects_dir = tmp_path / "projects"
+        project = projects_dir / "-home-user-my-hyphen-project"
+        project.mkdir(parents=True)
+        (project / "eeee-5555.jsonl").write_text(
+            json.dumps({"type": "user", "cwd": "/home/user/my-hyphen-project"}),
+            encoding="utf-8",
+        )
+        with patch("src.claude_code.CLAUDE_PROJECTS_DIR", str(projects_dir)):
+            assert get_claude_session_cwd("eeee-5555") == "/home/user/my-hyphen-project"
+
+    def test_session_cwd_falls_back_to_decoded_name(self, tmp_path):
+        """Empty transcript still yields a best-effort decoded cwd."""
+        projects_dir = tmp_path / "projects"
+        project = projects_dir / "-home-user-plain"
+        project.mkdir(parents=True)
+        (project / "ffff-6666.jsonl").write_text("{}", encoding="utf-8")
+        with (
+            patch("src.claude_code.CLAUDE_PROJECTS_DIR", str(projects_dir)),
+            patch("src.claude_code.sys") as mock_sys,
+        ):
+            mock_sys.platform = "linux"
+            assert get_claude_session_cwd("ffff-6666") == "/home/user/plain"
+
+
 # ── _extract_first_prompt_text ───────────────────────────────────────────────
 
 
@@ -409,6 +468,56 @@ class TestUnindexedSessionDiscovery:
         unindexed_session = next(s for s in sessions if s["id"] == f"{SESSION_ID_PREFIX}cccc-3333")
         assert unindexed_session["summary"] == "Unindexed session prompt"
         assert unindexed_session["source"] == "claude"
+
+    def test_unindexed_session_uses_transcript_cwd(self, tmp_path):
+        """Unindexed sessions get their cwd from the transcript, not the dir name."""
+        projects_dir = tmp_path / "projects"
+        project = projects_dir / "-home-user-my-hyphen-project"
+        project.mkdir(parents=True)
+        transcript = [
+            json.dumps({
+                "type": "user",
+                "cwd": "/home/user/my-hyphen-project",
+                "message": {"role": "user", "content": "Hello"},
+                "timestamp": "2026-03-01T12:00:00Z",
+            }),
+        ]
+        (project / "gggg-7777.jsonl").write_text("\n".join(transcript), encoding="utf-8")
+
+        with patch("src.claude_code.CLAUDE_PROJECTS_DIR", str(projects_dir)):
+            sessions = get_claude_sessions()
+
+        assert len(sessions) == 1
+        assert sessions[0]["cwd"] == "/home/user/my-hyphen-project"
+
+    def test_indexed_session_without_project_path_uses_transcript_cwd(self, tmp_path):
+        """Index entries lacking projectPath fall back to the transcript cwd."""
+        projects_dir = tmp_path / "projects"
+        project = projects_dir / "-home-user-my-hyphen-project"
+        project.mkdir(parents=True)
+        index = {
+            "version": 1,
+            "entries": [
+                {
+                    "sessionId": "hhhh-8888",
+                    "firstPrompt": "Hi",
+                    "messageCount": 1,
+                    "created": "2026-03-01T12:00:00Z",
+                    "modified": "2026-03-01T12:00:00Z",
+                }
+            ],
+        }
+        (project / "sessions-index.json").write_text(json.dumps(index), encoding="utf-8")
+        (project / "hhhh-8888.jsonl").write_text(
+            json.dumps({"type": "user", "cwd": "/home/user/my-hyphen-project"}),
+            encoding="utf-8",
+        )
+
+        with patch("src.claude_code.CLAUDE_PROJECTS_DIR", str(projects_dir)):
+            sessions = get_claude_sessions()
+
+        indexed = next(s for s in sessions if s["id"] == f"{SESSION_ID_PREFIX}hhhh-8888")
+        assert indexed["cwd"] == "/home/user/my-hyphen-project"
 
     def test_no_index_file_still_finds_jsonl(self, tmp_path):
         """Project dir with no sessions-index.json still discovers JSONL files."""


### PR DESCRIPTION
Fixes #66

## Problem

`_decode_project_dir()` rebuilds a Claude Code session's working directory from the encoded `~/.claude/projects` folder name by replacing every dash with a path separator. Claude's encoding maps real hyphens and dots to dashes too, so the decoding is lossy: `/home/user/my-repo` and `app_1.2` style paths decode to nonexistent directories, silently breaking plan lookup (#50), the repository/branch badge, and generated restart commands. On POSIX the decoder also produced a doubled leading slash (`//home/...`) because absolute paths encode their leading `/` as a leading dash.

## Fix

Prefer the exact `cwd` that Claude Code records on transcript event lines (`~/.claude/projects/<encoded>/<session-id>.jsonl`), and keep the decoded directory name only as a best-effort fallback for empty transcripts:

- New `_cwd_from_transcript()` helper scans the first lines of a transcript for a recorded `cwd` (capped at 200 lines; results cached per path — a session's cwd never changes).
- `get_claude_session_cwd()` (used by the plan endpoint) now returns the transcript cwd first.
- Indexed sessions missing `projectPath` and unindexed transcript discovery both use the recorded cwd; `_session_from_transcript()` picks it up during the line scan it already does, so no extra I/O.
- The POSIX fallback decoder now strips the leading dash before prepending `/` (fixes the `//home/...` artifact).

This is platform-neutral: the recorded `cwd` is used verbatim, so Windows sessions resolve to their real `C:\...` paths with no decoding involved.

## Testing

- 7 new unit tests: transcript cwd extraction, hyphenated-path resolution, decoded-name fallback, indexed-entry and unindexed-discovery paths. Full suite: **437 passed, 2 skipped**.
- Live-tested against a real machine with 92 tracked sessions: before the fix, most Claude sessions resolved to nonexistent paths (e.g. `/home/jgroom/src/na/sales/saos10/translator` for repo `na-sales-saos10-translator`); after, **all 43 Claude sessions resolve to existing directories**, and a `PLAN.md` placed in a hyphenated repo is returned by `GET /api/session/cc:<id>/plan`.
