### PR TITLE
fix: surface Copilot's per-session plan.md from session-state

### DIFF
--- a/src/dashboard_api.py
+++ b/src/dashboard_api.py
@@ -301,6 +301,17 @@ def _normalize_session_root(cwd: str | None) -> str | None:
     return root
 
 
+def _copilot_session_plan_path(session_id: str) -> str | None:
+    """Return the plan file Copilot CLI keeps in the session-state directory.
+
+    Copilot writes the session's working plan to
+    ``~/.copilot/session-state/<session-id>/plan.md`` rather than the repo,
+    so it takes priority over the cwd filename search.
+    """
+    candidate = os.path.join(SESSION_STATE_DIR, session_id, "plan.md")
+    return candidate if os.path.isfile(candidate) else None
+
+
 def _resolve_plan_path(cwd: str | None, plan_files: list[str]) -> str | None:
     """Return the first matching plan file inside ``cwd``."""
     root = _normalize_session_root(cwd)
@@ -593,13 +604,20 @@ def api_session_plan(session_id: str):
     if err:
         return JSONResponse({"error": err}, status_code=400)
 
-    cwd = _resolve_session_cwd(session_id)
-    plan_path = _resolve_plan_path(cwd, _get_configured_plan_files())
+    plan_path = None
+    root = None
+    if not session_id.startswith(CC_PREFIX):
+        plan_path = _copilot_session_plan_path(session_id)
+        if plan_path:
+            root = os.path.abspath(os.path.join(SESSION_STATE_DIR, session_id))
+    if not plan_path:
+        cwd = _resolve_session_cwd(session_id)
+        plan_path = _resolve_plan_path(cwd, _get_configured_plan_files())
+        root = _normalize_session_root(cwd)
     if not plan_path:
         return {"path": None, "content": None, "mtime": None, "progress": None}
 
     try:
-        root = _normalize_session_root(cwd)
         if not root or os.path.commonpath([root, plan_path]) != root:
             return {"path": None, "content": None, "mtime": None, "progress": None}
         with open(plan_path, encoding="utf-8", errors="replace") as f:

--- a/tests/test_dashboard_api_extra.py
+++ b/tests/test_dashboard_api_extra.py
@@ -189,6 +189,82 @@ class TestSessionPlan:
         assert data["progress"] == {"done": 1, "total": 2}
         assert data["mtime"]
 
+    def test_session_state_plan_takes_priority(self, client, mock_db, tmp_path):
+        """Copilot's own plan.md in session-state wins over a repo plan file."""
+        conn, db_path = mock_db
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        (project_dir / "PLAN.md").write_text("repo plan", encoding="utf-8")
+        state_dir = tmp_path / "session-state"
+        session_dir = state_dir / "sess-state"
+        session_dir.mkdir(parents=True)
+        state_plan = session_dir / "plan.md"
+        state_plan.write_text("# Session plan\n\n- [x] a\n- [ ] b\n", encoding="utf-8")
+        conn.execute(
+            "INSERT INTO sessions VALUES (?,?,?,?,?,?,?)",
+            (
+                "sess-state",
+                str(project_dir),
+                "owner/repo",
+                "main",
+                "Test",
+                "2026-01-01T00:00:00Z",
+                "2026-01-02T00:00:00Z",
+            ),
+        )
+        conn.commit()
+
+        with (
+            patch("src.dashboard_api.DB_PATH", db_path),
+            patch("src.dashboard_api.SESSION_STATE_DIR", str(state_dir)),
+        ):
+            resp = client.get("/api/session/sess-state/plan")
+
+        data = resp.json()
+        assert resp.status_code == 200
+        assert data["path"] == str(state_plan)
+        assert data["content"] == "# Session plan\n\n- [x] a\n- [ ] b\n"
+        assert data["progress"] == {"done": 1, "total": 2}
+
+    def test_session_state_plan_found_without_repo_plan(self, client, mock_db, tmp_path):
+        """A session-state plan surfaces even when the repo has no plan file."""
+        conn, db_path = mock_db
+        state_dir = tmp_path / "session-state"
+        session_dir = state_dir / "sess-only-state"
+        session_dir.mkdir(parents=True)
+        (session_dir / "plan.md").write_text("state only", encoding="utf-8")
+        conn.execute(
+            "INSERT INTO sessions VALUES (?,?,?,?,?,?,?)",
+            ("sess-only-state", None, None, None, "Test", "2026-01-01T00:00:00Z", "2026-01-02T00:00:00Z"),
+        )
+        conn.commit()
+
+        with (
+            patch("src.dashboard_api.DB_PATH", db_path),
+            patch("src.dashboard_api.SESSION_STATE_DIR", str(state_dir)),
+            patch("src.dashboard_api.get_session_event_data", return_value=EventData()),
+        ):
+            resp = client.get("/api/session/sess-only-state/plan")
+
+        assert resp.status_code == 200
+        assert resp.json()["content"] == "state only"
+
+    def test_claude_sessions_skip_session_state_lookup(self, client, tmp_path):
+        """cc: sessions never read Copilot session-state, even on id collision."""
+        state_dir = tmp_path / "session-state"
+        session_dir = state_dir / "aaaa-1111"
+        session_dir.mkdir(parents=True)
+        (session_dir / "plan.md").write_text("copilot plan", encoding="utf-8")
+
+        with (
+            patch("src.dashboard_api.SESSION_STATE_DIR", str(state_dir)),
+            patch("src.dashboard_api.get_claude_session_cwd", return_value=None),
+        ):
+            resp = client.get("/api/session/cc:aaaa-1111/plan")
+
+        assert resp.status_code == 200
+        assert resp.json()["content"] is None
+
     def test_uses_events_cwd_when_db_cwd_missing(self, client, mock_db, tmp_path):
         conn, db_path = mock_db
         project_dir = tmp_path / "events-project"


### PR DESCRIPTION
Fixes #67

## Problem

Copilot CLI writes the session's working plan to `~/.copilot/session-state/<session-id>/plan.md`, not to the repository. The plan viewer added in #50 only searches the session's cwd for the configured filenames (`PLAN.md`, `TASK.md`, `plan.md`, `docs/PLAN.md`), so Copilot's own plans never surface — on a machine where most session-state dirs contain a `plan.md`, the dashboard showed `No plan file.` for every one of them.

## Fix

`GET /api/session/{id}/plan` now resolves in priority order for Copilot sessions:

1. `~/.copilot/session-state/<session-id>/plan.md` — the session's own plan
2. The existing cwd + `planFiles` config search (unchanged fallback)

Notes:

- The out-of-root read guard is kept: the allowed root is the session's own state directory when the plan comes from session-state, and the session cwd otherwise.
- Joining `session_id` into the path is traversal-safe because `_SESSION_ID_RE` only admits `[a-zA-Z0-9_-]`.
- Claude (`cc:`) sessions never consult session-state, so an id collision can't leak another session's plan.
- Path built with `os.path.join` on `SESSION_STATE_DIR`, so it works the same on Windows.

## Testing

- 3 new unit tests: session-state plan takes priority over a repo plan, session-state plan surfaces when the repo has none, and `cc:` sessions skip the session-state lookup. Full suite: **433 passed, 2 skipped**.
- Live-tested on real data: `GET /api/session/5dc01d2a-.../plan` previously returned the empty state; with the fix it returns the session's actual 6.4 KB plan from `~/.copilot/session-state/5dc01d2a-.../plan.md`.
