### PR TITLE
fix: don't style unknown-state sessions as active in list view

### DIFF
--- a/frontend/src/test/helpers.test.ts
+++ b/frontend/src/test/helpers.test.ts
@@ -197,6 +197,10 @@ describe("listCardClass()", () => {
     expect(listCardClass(true, "working")).toBe("active-session");
   });
 
+  it("returns empty string for unknown state", () => {
+    expect(listCardClass(true, "unknown")).toBe("");
+  });
+
   it("returns empty string when not running", () => {
     expect(listCardClass(false, "working")).toBe("");
   });

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -33,7 +33,8 @@ export function listCardClass(
   if (!isRunning) return "";
   if (state === "waiting") return "waiting-session";
   if (state === "idle") return "idle-session";
-  return "active-session";
+  if (state === "working" || state === "thinking") return "active-session";
+  return "";
 }
 
 /**


### PR DESCRIPTION
## Summary

`listCardClass` returned `"active-session"` for any running session that wasn't `waiting` or `idle`. As a result, sessions in the `unknown` state were painted with the active (green) list styling even though they aren't actively working.

## Change

- Return `"active-session"` only for the `working` and `thinking` states; return an empty class for anything else (including `unknown`), so those cards render neutrally.
- Add a regression test covering the `unknown` state.

## Before / After

An `unknown`-state running session in list view. Before, it gets the green "active" left border; after, it renders neutrally (an `idle` session is shown below it for contrast, keeping its blue border in both).

**Before**

![before](https://raw.githubusercontent.com/Menny1337/ghcpCliDashboard/pr-70-assets/.github/pr-assets/70/before.png)

**After**

![after](https://raw.githubusercontent.com/Menny1337/ghcpCliDashboard/pr-70-assets/.github/pr-assets/70/after.png)

## Testing

- `npx tsc --noEmit` — clean
- `npm test` — all frontend tests pass