### PR TITLE
fix: ignore trailing hook/lifecycle events when resolving session state

### DIFF
--- a/src/process_tracker.py
+++ b/src/process_tracker.py
@@ -44,6 +44,25 @@ CREATE_NO_WINDOW = getattr(subprocess, "CREATE_NO_WINDOW", 0x08000000)
 # Tool names that indicate "waiting for user input"
 WAITING_TOOLS = frozenset({"ask_user", "ask_permission"})
 
+# Event types that can trail a completed turn without changing the session's
+# conversational state (hooks, session lifecycle, system notices). These are
+# skipped when resolving the "last meaningful event" so a session that ended on
+# assistant.turn_end is still reported as idle even when hooks ran afterward.
+NON_CONVERSATIONAL_EVENTS = frozenset(
+    {
+        "hook.start",
+        "hook.end",
+        "session.start",
+        "session.resume",
+        "session.shutdown",
+        "session.model_change",
+        "session.context_changed",
+        "session.warning",
+        "subagent.selected",
+        "system.message",
+    }
+)
+
 # ---------------------------------------------------------------------------
 # Caching layer
 # ---------------------------------------------------------------------------
@@ -185,8 +204,17 @@ def _get_session_state(session_id) -> SessionState:
             state="working", waiting_context="", bg_tasks=bg, bg_task_list=bg_task_list
         )
 
-    # Fall back to last event type
-    last = events[-1]
+    # Fall back to the last meaningful event, skipping trailing hook/lifecycle
+    # events that fire after a turn ends without changing conversational state.
+    last = None
+    for ev in reversed(events):
+        if ev.get("type", "") not in NON_CONVERSATIONAL_EVENTS:
+            last = ev
+            break
+    if last is None:
+        return SessionState(
+            state="unknown", waiting_context="", bg_tasks=bg, bg_task_list=bg_task_list
+        )
     etype = last.get("type", "")
     data = last.get("data", {})
 

--- a/tests/test_process_tracker.py
+++ b/tests/test_process_tracker.py
@@ -211,6 +211,22 @@ class TestGetSessionState:
             result = _get_session_state("sess-1")
         assert result["state"] == "working"
 
+    def test_trailing_hooks_after_turn_end_returns_idle(self, tmp_path):
+        events = [
+            {
+                "type": "tool.execution_start",
+                "data": {"toolCallId": "tc1", "toolName": "view", "arguments": {}},
+            },
+            {"type": "tool.execution_complete", "data": {"toolCallId": "tc1"}},
+            {"type": "assistant.turn_end", "data": {}},
+            {"type": "hook.start", "data": {}},
+            {"type": "hook.end", "data": {}},
+        ]
+        self._write_events(tmp_path, "sess-1", events)
+        with patch("src.process_tracker.EVENTS_DIR", str(tmp_path)):
+            result = _get_session_state("sess-1")
+        assert result["state"] == "idle"
+
     def test_stale_pending_tool_returns_waiting(self, tmp_path):
         old_time = (datetime.now(UTC) - timedelta(seconds=120)).isoformat()
         events = [


### PR DESCRIPTION
## Summary

When `_get_session_state` falls back to the last event to infer a session's state, it took `events[-1]` unconditionally. Hook and session-lifecycle events can be written after a turn ends without changing the conversational state, so a session that finished on `assistant.turn_end` could be misreported (e.g. not shown as idle) once a `hook.start`/`hook.end` pair trailed it.

## Change

- Introduce `NON_CONVERSATIONAL_EVENTS` (hook.start/end, session.start/resume/shutdown/model_change/context_changed/warning, subagent.selected, system.message).
- Walk backwards to the last meaningful event, skipping those types, and fall back to `unknown` only when no meaningful event exists.
- Add a regression test asserting a session ending on `assistant.turn_end` followed by hook events reports `idle`.

## Testing

- `ruff check src/` / `ruff format --check src/` — clean
- `mypy src/` — success
- `pytest tests/test_process_tracker.py` — 118 passed
