### PR TITLE
feat: add "Recently changed status" sort for active sessions

### DIFF
--- a/frontend/src/components/SessionGrid.tsx
+++ b/frontend/src/components/SessionGrid.tsx
@@ -19,7 +19,7 @@ interface SessionGridProps {
 }
 
 export default function SessionGrid({ sessions, processes, isActive }: SessionGridProps) {
-  const { starredSessions, groupBy, collapsedGroups, lastFetchedAt } = useAppState();
+  const { starredSessions, groupBy, sortMode, statusChangedAt, collapsedGroups, lastFetchedAt } = useAppState();
   const dispatch = useAppDispatch();
   const [modalSession, setModalSession] = useState<{ id: string; title: string } | null>(null);
 
@@ -40,7 +40,7 @@ export default function SessionGrid({ sessions, processes, isActive }: SessionGr
   return (
     <>
       {groups.map(([groupName, items]) => {
-        const sorted = sortStarredFirst(items, starredSessions);
+        const sorted = sortStarredFirst(items, starredSessions, sortMode, statusChangedAt);
         const gid = `tile-${groupName}`.replace(/[^a-zA-Z0-9]/g, "_");
         const isCollapsed = collapsedGroups.has(gid);
 

--- a/frontend/src/components/SessionList.tsx
+++ b/frontend/src/components/SessionList.tsx
@@ -17,7 +17,7 @@ interface SessionListProps {
 }
 
 export default function SessionList({ sessions, processes, isActive, panelId }: SessionListProps) {
-  const { collapsedGroups, starredSessions, groupBy, lastFetchedAt } = useAppState();
+  const { collapsedGroups, starredSessions, groupBy, sortMode, statusChangedAt, lastFetchedAt } = useAppState();
   const dispatch = useAppDispatch();
 
   if (sessions.length === 0) {
@@ -39,7 +39,7 @@ export default function SessionList({ sessions, processes, isActive, panelId }: 
       {groups.map(([groupName, items]) => {
         const gid = `${panelId}-${groupName}`.replace(/[^a-zA-Z0-9]/g, "_");
         const isCollapsed = collapsedGroups.has(gid);
-        const sorted = sortStarredFirst(items, starredSessions);
+        const sorted = sortStarredFirst(items, starredSessions, sortMode, statusChangedAt);
 
         return (
           <div key={gid} className="group">

--- a/frontend/src/components/TabBar.tsx
+++ b/frontend/src/components/TabBar.tsx
@@ -5,7 +5,7 @@
 
 import { TOOLTIP_DELAY_MS } from "../constants";
 import { useNotifications } from "../hooks";
-import { useAppState, useAppDispatch, type Tab, type View, type GroupBy } from "../state";
+import { useAppState, useAppDispatch, type Tab, type View, type GroupBy, type SortMode } from "../state";
 import { useRef, useState, useCallback } from "react";
 
 interface TabBarProps {
@@ -14,7 +14,7 @@ interface TabBarProps {
 }
 
 export default function TabBar({ activeCount, previousCount }: TabBarProps) {
-  const { currentTab, currentView, groupBy } = useAppState();
+  const { currentTab, currentView, groupBy, sortMode } = useAppState();
   const dispatch = useAppDispatch();
   const { notificationsEnabled, toggle: toggleNotif, popoverContent } =
     useNotifications();
@@ -40,6 +40,7 @@ export default function TabBar({ activeCount, previousCount }: TabBarProps) {
 
   const setView = (view: View) => dispatch({ type: "SET_VIEW", view });
   const setGroupBy = (g: GroupBy) => dispatch({ type: "SET_GROUP_BY", groupBy: g });
+  const setSortMode = (m: SortMode) => dispatch({ type: "SET_SORT_MODE", sortMode: m });
 
   const tabs: { key: Tab; label: string; icon: string; count?: number; title: string }[] = [
     { key: "active", label: "Active", icon: "⚡", count: activeCount, title: "Currently running Copilot CLI sessions" },
@@ -96,6 +97,18 @@ export default function TabBar({ activeCount, previousCount }: TabBarProps) {
             <option value="none">No grouping</option>
             <option value="project">Group by project</option>
             <option value="machine">Group by machine</option>
+          </select>
+        )}
+
+        {currentTab === "active" && (
+          <select
+            className="palette-select"
+            value={sortMode}
+            onChange={(e) => setSortMode(e.target.value as SortMode)}
+            data-tip="Sort running sessions by"
+          >
+            <option value="default">Default order</option>
+            <option value="status_changed">Recently changed status</option>
           </select>
         )}
 

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -60,6 +60,8 @@ export const STORAGE_KEY_VIEW = "dash-view";
 export const STORAGE_KEY_STARRED = "dash-starred";
 export const STORAGE_KEY_WIDGETS_COLLAPSED = "dash-widgets-collapsed";
 export const STORAGE_KEY_GROUP_BY = "dash-group-by";
+export const STORAGE_KEY_SORT = "dash-sort";
+export const STORAGE_KEY_STATUS_CHANGED = "dash-status-changed";
 
 // ── Theme options ──────────────────────────────────────────────────────────
 

--- a/frontend/src/hooks/useSessions.ts
+++ b/frontend/src/hooks/useSessions.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef } from "react";
 import { fetchSessions, fetchProcesses, fetchRemoteSessions } from "../api";
 import { BACKGROUND_POLL_MS, PROCESS_POLL_MS, SESSION_POLL_MS } from "../constants";
 import { useAppState, useAppDispatch } from "../state";
+import { computeStatusChanges } from "../utils";
 import type { ProcessMap } from "../types";
 
 /**
@@ -19,12 +20,14 @@ import type { ProcessMap } from "../types";
  */
 export function useSessions() {
   const dispatch = useAppDispatch();
-  const { notificationsEnabled, sessions, processes } = useAppState();
+  const { notificationsEnabled, sessions, processes, statusChangedAt } = useAppState();
   const prevProcesses = useRef<ProcessMap>({});
   const sessionsRef = useRef(sessions);
   const notifRef = useRef(notificationsEnabled);
+  const statusChangedRef = useRef(statusChangedAt);
   sessionsRef.current = sessions;
   notifRef.current = notificationsEnabled;
+  statusChangedRef.current = statusChangedAt;
 
   // Full session + process + remote fetch
   const fetchAll = async () => {
@@ -35,6 +38,7 @@ export function useSessions() {
       ]);
       dispatch({ type: "SET_SESSIONS", sessions: sess });
       checkTransitions(prevProcesses.current, procs);
+      recordStatusChanges(prevProcesses.current, procs, sess);
       prevProcesses.current = procs;
       dispatch({ type: "SET_PROCESSES", processes: procs });
       dispatch({ type: "RECORD_FETCH_SUCCESS" });
@@ -53,11 +57,35 @@ export function useSessions() {
     try {
       const procs = await fetchProcesses();
       checkTransitions(prevProcesses.current, procs);
+      recordStatusChanges(prevProcesses.current, procs, sessionsRef.current);
       prevProcesses.current = procs;
       dispatch({ type: "SET_PROCESSES", processes: procs });
       dispatch({ type: "RECORD_FETCH_SUCCESS" });
     } catch {
       dispatch({ type: "RECORD_FETCH_FAILURE" });
+    }
+  };
+
+  // Record the time a running session transitions INTO an actionable status
+  // (`waiting` or `idle`). Runs on every poll, independent of the notification
+  // setting, so the "recently changed status" sort has data to work with.
+  const recordStatusChanges = (
+    oldP: ProcessMap,
+    newP: ProcessMap,
+    sessionsList: typeof sessions,
+  ) => {
+    const changes = computeStatusChanges(
+      oldP,
+      newP,
+      sessionsList,
+      statusChangedRef.current,
+    );
+    if (Object.keys(changes).length > 0) {
+      dispatch({
+        type: "RECORD_STATUS_CHANGES",
+        changes,
+        presentIds: Object.keys(newP),
+      });
     }
   };
 

--- a/frontend/src/state/AppContext.tsx
+++ b/frontend/src/state/AppContext.tsx
@@ -22,7 +22,9 @@ import {
 import {
   DISCONNECT_THRESHOLD,
   STORAGE_KEY_GROUP_BY,
+  STORAGE_KEY_SORT,
   STORAGE_KEY_STARRED,
+  STORAGE_KEY_STATUS_CHANGED,
   STORAGE_KEY_VIEW,
   STORAGE_KEY_WIDGETS_COLLAPSED,
 } from "../constants";
@@ -33,9 +35,11 @@ import type { Session, ProcessMap } from "../types";
 export type Tab = "active" | "previous" | "timeline" | "files";
 export type View = "tile" | "list";
 export type GroupBy = "none" | "project" | "machine";
+export type SortMode = "default" | "status_changed";
 
 const VALID_VIEWS: View[] = ["tile", "list"];
 const VALID_GROUP_BY: GroupBy[] = ["none", "project", "machine"];
+const VALID_SORTS: SortMode[] = ["default", "status_changed"];
 
 function safeParseStarred(): Set<string> {
   try {
@@ -47,6 +51,22 @@ function safeParseStarred(): Set<string> {
   return new Set();
 }
 
+function safeParseStatusChanged(): Record<string, number> {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY_STATUS_CHANGED);
+    if (!raw) return {};
+    const obj = JSON.parse(raw);
+    if (obj && typeof obj === "object" && !Array.isArray(obj)) {
+      const out: Record<string, number> = {};
+      for (const [k, v] of Object.entries(obj)) {
+        if (typeof v === "number" && Number.isFinite(v)) out[k] = v;
+      }
+      return out;
+    }
+  } catch { /* corrupt localStorage */ }
+  return {};
+}
+
 export interface AppState {
   sessions: Session[];
   remoteSessions: Session[];
@@ -54,6 +74,9 @@ export interface AppState {
   currentTab: Tab;
   currentView: View;
   groupBy: GroupBy;
+  sortMode: SortMode;
+  /** Epoch ms a running session most recently entered `waiting` or `idle`. */
+  statusChangedAt: Record<string, number>;
   searchFilter: string;
   expandedSessionIds: Set<string>;
   collapsedGroups: Set<string>;
@@ -74,6 +97,8 @@ export function initialState(): AppState {
   const currentView: View = rawView && VALID_VIEWS.includes(rawView) ? rawView : "tile";
   const rawGroupBy = localStorage.getItem(STORAGE_KEY_GROUP_BY) as GroupBy | null;
   const groupBy: GroupBy = rawGroupBy && VALID_GROUP_BY.includes(rawGroupBy) ? rawGroupBy : "none";
+  const rawSort = localStorage.getItem(STORAGE_KEY_SORT) as SortMode | null;
+  const sortMode: SortMode = rawSort && VALID_SORTS.includes(rawSort) ? rawSort : "default";
   return {
     sessions: [],
     remoteSessions: [],
@@ -81,6 +106,8 @@ export function initialState(): AppState {
     currentTab: "active",
     currentView,
     groupBy,
+    sortMode,
+    statusChangedAt: safeParseStatusChanged(),
     searchFilter: "",
     expandedSessionIds: new Set(),
     collapsedGroups: new Set(),
@@ -106,6 +133,8 @@ export type Action =
   | { type: "SET_TAB"; tab: Tab }
   | { type: "SET_VIEW"; view: View }
   | { type: "SET_GROUP_BY"; groupBy: GroupBy }
+  | { type: "SET_SORT_MODE"; sortMode: SortMode }
+  | { type: "RECORD_STATUS_CHANGES"; changes: Record<string, number>; presentIds: string[] }
   | { type: "SET_SEARCH"; filter: string }
   | { type: "TOGGLE_EXPAND"; sessionId: string }
   | { type: "TOGGLE_GROUP"; groupId: string }
@@ -138,6 +167,22 @@ export function appReducer(state: AppState, action: Action): AppState {
 
     case "SET_GROUP_BY":
       return { ...state, groupBy: action.groupBy };
+
+    case "SET_SORT_MODE":
+      return { ...state, sortMode: action.sortMode };
+
+    case "RECORD_STATUS_CHANGES": {
+      const present = new Set(action.presentIds);
+      const next: Record<string, number> = {};
+      // Keep only currently-present (running) sessions to stay bounded.
+      for (const [id, ts] of Object.entries(state.statusChangedAt)) {
+        if (present.has(id)) next[id] = ts;
+      }
+      for (const [id, ts] of Object.entries(action.changes)) {
+        next[id] = ts;
+      }
+      return { ...state, statusChangedAt: next };
+    }
 
     case "SET_SEARCH":
       return { ...state, searchFilter: action.filter };
@@ -219,6 +264,14 @@ export function AppProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     localStorage.setItem(STORAGE_KEY_GROUP_BY, state.groupBy);
   }, [state.groupBy]);
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY_SORT, state.sortMode);
+  }, [state.sortMode]);
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY_STATUS_CHANGED, JSON.stringify(state.statusChangedAt));
+  }, [state.statusChangedAt]);
 
   useEffect(() => {
     localStorage.setItem(STORAGE_KEY_STARRED, JSON.stringify([...state.starredSessions]));

--- a/frontend/src/state/index.ts
+++ b/frontend/src/state/index.ts
@@ -1,3 +1,3 @@
 export { AppProvider, useAppState, useAppDispatch, isDisconnected } from "./AppContext";
 export { appReducer, initialState } from "./AppContext";
-export type { AppState, Action, Tab, View, GroupBy } from "./AppContext";
+export type { AppState, Action, Tab, View, GroupBy, SortMode } from "./AppContext";

--- a/frontend/src/test/components.test.tsx
+++ b/frontend/src/test/components.test.tsx
@@ -475,6 +475,22 @@ describe("TabBar", () => {
     renderWithProvider(<TabBar activeCount={0} previousCount={0} />);
     expect(screen.getByText(/Notifications/)).toBeInTheDocument();
   });
+
+  it("renders the sort control on the Active tab", () => {
+    renderWithProvider(<TabBar activeCount={0} previousCount={0} />);
+    const sortSelect = document.querySelector('[data-tip="Sort running sessions by"]');
+    expect(sortSelect).toBeInTheDocument();
+    expect(screen.getByText("Recently changed status")).toBeInTheDocument();
+  });
+
+  it("dispatches SET_SORT_MODE when the sort control changes", () => {
+    renderWithProvider(<TabBar activeCount={0} previousCount={0} />);
+    const sortSelect = document.querySelector(
+      '[data-tip="Sort running sessions by"]',
+    ) as HTMLSelectElement;
+    fireEvent.change(sortSelect, { target: { value: "status_changed" } });
+    expect(sortSelect.value).toBe("status_changed");
+  });
 });
 
 // ── Tooltip ──────────────────────────────────────────────────────────────────

--- a/frontend/src/test/helpers.test.ts
+++ b/frontend/src/test/helpers.test.ts
@@ -10,9 +10,10 @@ import {
   groupSessions,
   sortStarredFirst,
   listCardClass,
+  computeStatusChanges,
   STATE_LABELS,
 } from "../utils/helpers";
-import type { Session, ProcessInfo } from "../types";
+import type { Session, ProcessInfo, ProcessMap } from "../types";
 
 /** Minimal session factory for tests. */
 function makeSession(overrides: Partial<Session> = {}): Session {
@@ -181,6 +182,117 @@ describe("sortStarredFirst()", () => {
     ];
     const sorted = sortStarredFirst(sessions, new Set());
     expect(sorted.map(s => s.id)).toEqual(["b", "c", "a"]);
+  });
+
+  describe("status_changed sort mode", () => {
+    it("orders running sessions by most recent status change first", () => {
+      const sessions = [
+        makeSession({ id: "a", is_running: true, state: "idle", updated_at: "2026-01-01T01:00:00Z" }),
+        makeSession({ id: "b", is_running: true, state: "waiting", updated_at: "2026-01-01T01:00:00Z" }),
+        makeSession({ id: "c", is_running: true, state: "idle", updated_at: "2026-01-01T01:00:00Z" }),
+      ];
+      const changed = { a: 100, b: 300, c: 200 };
+      const sorted = sortStarredFirst(sessions, new Set(), "status_changed", changed);
+      expect(sorted.map(s => s.id)).toEqual(["b", "c", "a"]);
+    });
+
+    it("puts running sessions without a status-change timestamp at the bottom", () => {
+      const sessions = [
+        makeSession({ id: "working", is_running: true, state: "working", updated_at: "2026-01-01T05:00:00Z" }),
+        makeSession({ id: "waited", is_running: true, state: "waiting", updated_at: "2026-01-01T01:00:00Z" }),
+      ];
+      const changed = { waited: 500 };
+      const sorted = sortStarredFirst(sessions, new Set(), "status_changed", changed);
+      expect(sorted.map(s => s.id)).toEqual(["waited", "working"]);
+    });
+
+    it("still ranks running sessions before non-running ones", () => {
+      const sessions = [
+        makeSession({ id: "prev", is_running: false, updated_at: "2026-01-01T09:00:00Z" }),
+        makeSession({ id: "run", is_running: true, state: "idle", updated_at: "2026-01-01T01:00:00Z" }),
+      ];
+      const sorted = sortStarredFirst(sessions, new Set(), "status_changed", { run: 100 });
+      expect(sorted[0].id).toBe("run");
+    });
+
+    it("default mode ignores the status-change timestamps", () => {
+      const sessions = [
+        makeSession({ id: "a", is_running: true, state: "waiting", updated_at: "2026-01-01T02:00:00Z" }),
+        makeSession({ id: "b", is_running: true, state: "working", updated_at: "2026-01-01T01:00:00Z" }),
+      ];
+      // With status_changed data present, default mode should still rank by
+      // state priority (working before waiting).
+      const sorted = sortStarredFirst(sessions, new Set(), "default", { a: 999 });
+      expect(sorted.map(s => s.id)).toEqual(["b", "a"]);
+    });
+  });
+});
+
+describe("computeStatusChanges()", () => {
+  function makeProc(state: ProcessInfo["state"]): ProcessInfo {
+    return {
+      pid: 1,
+      parent_pid: 0,
+      terminal_pid: 0,
+      terminal_name: "",
+      cmdline: "",
+      yolo: false,
+      state,
+      waiting_context: "",
+      bg_tasks: 0,
+      bg_task_list: [],
+      mcp_servers: [],
+      window_title: "",
+    };
+  }
+
+  it("stamps `now` on a live transition into waiting", () => {
+    const oldP: ProcessMap = { s1: makeProc("working") };
+    const newP: ProcessMap = { s1: makeProc("waiting") };
+    const changes = computeStatusChanges(oldP, newP, [], {}, 5000);
+    expect(changes).toEqual({ s1: 5000 });
+  });
+
+  it("stamps `now` on a live transition into idle", () => {
+    const oldP: ProcessMap = { s1: makeProc("thinking") };
+    const newP: ProcessMap = { s1: makeProc("idle") };
+    const changes = computeStatusChanges(oldP, newP, [], {}, 7000);
+    expect(changes).toEqual({ s1: 7000 });
+  });
+
+  it("does not record transitions into working or thinking", () => {
+    const oldP: ProcessMap = { s1: makeProc("idle") };
+    const newP: ProcessMap = { a: makeProc("working"), b: makeProc("thinking") };
+    const changes = computeStatusChanges(oldP, newP, [], {}, 5000);
+    expect(changes).toEqual({});
+  });
+
+  it("ignores a session that stays in the same actionable state", () => {
+    const oldP: ProcessMap = { s1: makeProc("waiting") };
+    const newP: ProcessMap = { s1: makeProc("waiting") };
+    const changes = computeStatusChanges(oldP, newP, [], {}, 5000);
+    expect(changes).toEqual({});
+  });
+
+  it("seeds from updated_at when a session is first seen already actionable", () => {
+    const newP: ProcessMap = { s1: makeProc("waiting") };
+    const sessions = [makeSession({ id: "s1", updated_at: "2026-01-01T00:00:00Z" })];
+    const changes = computeStatusChanges({}, newP, sessions, {}, 5000);
+    expect(changes).toEqual({ s1: Date.parse("2026-01-01T00:00:00Z") });
+  });
+
+  it("falls back to `now` when first-seen session has no parseable updated_at", () => {
+    const newP: ProcessMap = { s1: makeProc("idle") };
+    const sessions = [makeSession({ id: "s1", updated_at: "" })];
+    const changes = computeStatusChanges({}, newP, sessions, {}, 5000);
+    expect(changes).toEqual({ s1: 5000 });
+  });
+
+  it("does not overwrite an existing recorded timestamp on first observation", () => {
+    const newP: ProcessMap = { s1: makeProc("waiting") };
+    const sessions = [makeSession({ id: "s1", updated_at: "2026-01-01T00:00:00Z" })];
+    const changes = computeStatusChanges({}, newP, sessions, { s1: 999 }, 5000);
+    expect(changes).toEqual({});
   });
 });
 

--- a/frontend/src/test/reducer.test.ts
+++ b/frontend/src/test/reducer.test.ts
@@ -61,6 +61,29 @@ describe("initialState()", () => {
     const s = initialState();
     expect(s.groupBy).toBe("none");
   });
+
+  it("defaults sortMode to default", () => {
+    expect(state.sortMode).toBe("default");
+    expect(state.statusChangedAt).toEqual({});
+  });
+
+  it("reads sortMode preference from localStorage", () => {
+    store["dash-sort"] = "status_changed";
+    const s = initialState();
+    expect(s.sortMode).toBe("status_changed");
+  });
+
+  it("ignores invalid sortMode in localStorage", () => {
+    store["dash-sort"] = "bogus";
+    const s = initialState();
+    expect(s.sortMode).toBe("default");
+  });
+
+  it("reads statusChangedAt from localStorage, dropping non-numeric values", () => {
+    store["dash-status-changed"] = JSON.stringify({ a: 123, b: "nope", c: 456 });
+    const s = initialState();
+    expect(s.statusChangedAt).toEqual({ a: 123, c: 456 });
+  });
 });
 
 describe("appReducer", () => {
@@ -72,6 +95,22 @@ describe("appReducer", () => {
   it("SET_VIEW changes view", () => {
     const next = appReducer(state, { type: "SET_VIEW", view: "list" });
     expect(next.currentView).toBe("list");
+  });
+
+  it("SET_SORT_MODE changes sort mode", () => {
+    const next = appReducer(state, { type: "SET_SORT_MODE", sortMode: "status_changed" });
+    expect(next.sortMode).toBe("status_changed");
+  });
+
+  it("RECORD_STATUS_CHANGES merges changes and prunes absent sessions", () => {
+    state = { ...state, statusChangedAt: { old: 1, keep: 2 } };
+    const next = appReducer(state, {
+      type: "RECORD_STATUS_CHANGES",
+      changes: { keep: 99, fresh: 50 },
+      presentIds: ["keep", "fresh"],
+    });
+    // "old" pruned (not present), "keep" updated, "fresh" added
+    expect(next.statusChangedAt).toEqual({ keep: 99, fresh: 50 });
   });
 
   it("SET_SEARCH updates filter", () => {

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -10,7 +10,8 @@ import {
   STATE_LABELS,
   TILE_STATE_CLASS,
 } from "../constants";
-import type { Session, ProcessInfo } from "../types";
+import type { Session, ProcessInfo, ProcessMap } from "../types";
+import type { SortMode } from "../state";
 
 // Re-export the constant lookup tables so existing imports keep working
 export { STATE_LABELS, STATE_BADGE_CLASS, TILE_STATE_CLASS };
@@ -133,6 +134,8 @@ const STATE_PRIORITY: Record<string, number> = {
 export function sortStarredFirst(
   sessions: Session[],
   starred: Set<string>,
+  sortMode: SortMode = "default",
+  statusChangedAt: Record<string, number> = {},
 ): Session[] {
   return [...sessions].sort((a, b) => {
     // Running sessions first
@@ -143,13 +146,63 @@ export function sortStarredFirst(
       const sb = starred.has(b.id) ? 1 : 0;
       if (sa !== sb) return sb - sa;
     }
-    // Among running: sort by state (working > thinking > waiting > idle)
-    if (a.is_running && b.is_running && a.state !== b.state) {
-      const pa = STATE_PRIORITY[a.state ?? "unknown"] ?? 4;
-      const pb = STATE_PRIORITY[b.state ?? "unknown"] ?? 4;
-      if (pa !== pb) return pa - pb;
+    // Among running sessions, order depends on the selected sort mode
+    if (a.is_running && b.is_running) {
+      if (sortMode === "status_changed") {
+        // Most recently entered waiting/idle first; sessions that never became
+        // actionable (no recorded timestamp) fall to the bottom of the group.
+        const ta = statusChangedAt[a.id];
+        const tb = statusChangedAt[b.id];
+        const hasA = ta !== undefined;
+        const hasB = tb !== undefined;
+        if (hasA !== hasB) return hasA ? -1 : 1;
+        if (hasA && hasB && ta !== tb) return tb - ta;
+      } else if (a.state !== b.state) {
+        // Default: sort by state (working > thinking > waiting > idle)
+        const pa = STATE_PRIORITY[a.state ?? "unknown"] ?? 4;
+        const pb = STATE_PRIORITY[b.state ?? "unknown"] ?? 4;
+        if (pa !== pb) return pa - pb;
+      }
     }
     // Then by most recent activity (updated_at descending)
     return b.updated_at.localeCompare(a.updated_at);
   });
+}
+
+/**
+ * Diff two process polls and return the sessions that just entered an
+ * actionable status (`waiting` or `idle`), mapped to the epoch-ms time of the
+ * change. Only these transitions are interesting for the "recently changed
+ * status" sort — `working`/`thinking` flips are ignored.
+ *
+ * - A genuine live transition (previous state known and different) is stamped
+ *   with `now`.
+ * - A session first seen already in waiting/idle is seeded from its
+ *   `updated_at` (best proxy), but only when there is no existing recorded
+ *   timestamp, so persisted values are never clobbered on reload.
+ */
+export function computeStatusChanges(
+  oldP: ProcessMap,
+  newP: ProcessMap,
+  sessions: Session[],
+  existing: Record<string, number>,
+  now: number = Date.now(),
+): Record<string, number> {
+  const changes: Record<string, number> = {};
+  for (const [sid, info] of Object.entries(newP)) {
+    const st = info.state;
+    if (st !== "waiting" && st !== "idle") continue;
+    const oldState = oldP[sid]?.state;
+    if (oldState === st) continue; // no transition
+    if (!oldState) {
+      if (existing[sid] === undefined) {
+        const s = sessions.find((x) => x.id === sid);
+        const ts = s?.updated_at ? Date.parse(s.updated_at) : NaN;
+        changes[sid] = Number.isNaN(ts) ? now : ts;
+      }
+    } else {
+      changes[sid] = now;
+    }
+  }
+  return changes;
 }

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -9,4 +9,5 @@ export {
   filterSessions,
   splitActivePrevious,
   sortStarredFirst,
+  computeStatusChanges,
 } from "./helpers";


### PR DESCRIPTION
## Summary

Adds a sort control to the Active tab that orders running sessions by how recently they entered an actionable status (`waiting` or `idle`), so sessions most likely to need attention float to the top. The default order (state priority) is unchanged and remains the default.

## Change

- Track the epoch-ms time each running session transitions into `waiting`/`idle` via a new `computeStatusChanges` helper, recorded on every poll independent of the notification setting.
- Persist the sort mode (`dash-sort`) and per-session timestamps (`dash-status-changed`) in localStorage. First-seen actionable sessions are seeded from `updated_at`; sessions that are no longer running are pruned to keep the map bounded.
- Extend `sortStarredFirst` with a `status_changed` mode.
- Wire new state fields, reducer actions (`SET_SORT_MODE`, `RECORD_STATUS_CHANGES`), and a TabBar dropdown shown on the Active tab.

## Testing

- `npx tsc --noEmit` — clean
- `npm test` — all frontend tests pass (reducer, helpers, and TabBar control covered)
