### PR TITLE
Fix in-app update restart mode + session loading UX

### DIFF
--- a/frontend/src/components/SessionGrid.tsx
+++ b/frontend/src/components/SessionGrid.tsx
@@ -19,13 +19,18 @@ interface SessionGridProps {
 }
 
 export default function SessionGrid({ sessions, processes, isActive }: SessionGridProps) {
-  const { starredSessions, groupBy, sortMode, statusChangedAt, collapsedGroups, lastFetchedAt } = useAppState();
+  const { starredSessions, groupBy, sortMode, statusChangedAt, collapsedGroups, sessionsLoaded } = useAppState();
   const dispatch = useAppDispatch();
   const [modalSession, setModalSession] = useState<{ id: string; title: string } | null>(null);
 
   if (sessions.length === 0) {
-    if (isActive && lastFetchedAt === null) {
-      return <div className="loading">Loading sessions…</div>;
+    if (!sessionsLoaded) {
+      return (
+        <div className="loading">
+          <div className="spinner" aria-hidden="true" />
+          <div>Loading sessions…</div>
+        </div>
+      );
     }
     return (
       <div className="empty">

--- a/frontend/src/components/SessionList.tsx
+++ b/frontend/src/components/SessionList.tsx
@@ -17,12 +17,17 @@ interface SessionListProps {
 }
 
 export default function SessionList({ sessions, processes, isActive, panelId }: SessionListProps) {
-  const { collapsedGroups, starredSessions, groupBy, sortMode, statusChangedAt, lastFetchedAt } = useAppState();
+  const { collapsedGroups, starredSessions, groupBy, sortMode, statusChangedAt, sessionsLoaded } = useAppState();
   const dispatch = useAppDispatch();
 
   if (sessions.length === 0) {
-    if (isActive && lastFetchedAt === null) {
-      return <div className="loading">Loading sessions…</div>;
+    if (!sessionsLoaded) {
+      return (
+        <div className="loading">
+          <div className="spinner" aria-hidden="true" />
+          <div>Loading sessions…</div>
+        </div>
+      );
     }
     return (
       <div className="empty">

--- a/frontend/src/components/SessionTile.tsx
+++ b/frontend/src/components/SessionTile.tsx
@@ -81,11 +81,6 @@ export default function SessionTile({ session: s, processInfo, onOpenDetail }: S
         >
           {(isRunning || isRemote) && s.intent ? `🤖 ${s.intent}` : s.summary || "(Untitled session)"}
         </div>
-        {isRunning && processInfo?.window_title && processInfo.window_title !== s.summary && !(s.intent && processInfo.window_title.includes(s.intent)) && (
-          <div className="tile-subtitle" style={{ opacity: 0.7 }} data-tip={`Window: ${processInfo.window_title}`}>
-            🪟 {processInfo.window_title}
-          </div>
-        )}
         {isRunning && processInfo!.yolo && (
           <span className="badge badge-yolo" style={{ flexShrink: 0 }} data-tip="YOLO mode enabled">🔥</span>
         )}
@@ -144,8 +139,8 @@ export default function SessionTile({ session: s, processInfo, onOpenDetail }: S
           <span key={m} className="badge badge-mcp">🔌 {m}</span>
         ))}
         {isRunning && !isRemote && (
-          <span className="badge badge-focus" onClick={(e) => { stop(e); focusSession(s.id).then((r) => { if (!r.success) showToast(r.message || "Could not focus window", "error"); }).catch(() => showToast("Focus request failed", "error")); }} data-tip="Focus terminal window">
-            👁️
+          <span className="badge badge-focus" onClick={(e) => { stop(e); focusSession(s.id).then((r) => { if (!r.success) showToast(r.message || "Could not focus window", "error"); }).catch(() => showToast("Focus request failed", "error")); }} data-tip={processInfo!.window_title ? `Focus window: ${processInfo!.window_title}` : "Focus terminal window"}>
+            🪟
           </span>
         )}
         {!isRemote && <span className="badge badge-focus" onClick={handleCopy} data-tip="Copy resume command">📋</span>}

--- a/frontend/src/components/StatsRow.tsx
+++ b/frontend/src/components/StatsRow.tsx
@@ -5,6 +5,7 @@
  */
 
 import type { Session, ProcessMap, BackgroundTask } from "../types";
+import { useAppState } from "../state";
 import BgTaskPopover from "./BgTaskPopover";
 
 interface StatsRowProps {
@@ -13,6 +14,46 @@ interface StatsRowProps {
 }
 
 export default function StatsRow({ active, processes }: StatsRowProps) {
+  const { sessionsLoaded } = useAppState();
+
+  // While the first session fetch is still in flight we don't yet know how many
+  // active sessions there are, so render the row with spinners in place of the
+  // numbers rather than flashing "0"s or hiding the row entirely. The card
+  // layout (including the "IN RUNNING SESSIONS" sub-line) mirrors the loaded
+  // state exactly so the swap from spinner to number causes no layout shift.
+  if (!sessionsLoaded) {
+    const spinner = (
+      <div className="stat-spinner">
+        <div className="spinner" aria-hidden="true" />
+      </div>
+    );
+    const loadingCards: { label: string; hasSub: boolean }[] = [
+      { label: "Running Now", hasSub: false },
+      { label: "Conversations", hasSub: true },
+      { label: "Tool Calls", hasSub: true },
+      { label: "Sub-agents", hasSub: true },
+      { label: "Background Tasks", hasSub: true },
+    ];
+    return (
+      <div className="stats-row" aria-busy="true">
+        {loadingCards.map(({ label, hasSub }) => (
+          <div className="stat-card" key={label}>
+            {spinner}
+            <div className="label">
+              {label}
+              {hasSub && (
+                <div style={{ fontSize: 9, opacity: 0.6, marginTop: 1 }}>
+                  IN RUNNING SESSIONS
+                </div>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  // Loaded, but nothing is running — the row has nothing useful to show.
   if (active.length === 0) return null;
 
   const turns = active.reduce((a, s) => a + (s.turn_count || 0), 0);

--- a/frontend/src/components/TabBar.tsx
+++ b/frontend/src/components/TabBar.tsx
@@ -43,7 +43,7 @@ export default function TabBar({ activeCount, previousCount }: TabBarProps) {
   const setSortMode = (m: SortMode) => dispatch({ type: "SET_SORT_MODE", sortMode: m });
 
   const tabs: { key: Tab; label: string; icon: string; count?: number; title: string }[] = [
-    { key: "active", label: "Active", icon: "⚡", count: activeCount, title: "Currently running Copilot CLI sessions" },
+    { key: "active", label: "Active", icon: "⚡", count: activeCount, title: "Currently running sessions" },
     { key: "previous", label: "Previous", icon: "📋", count: previousCount, title: "Completed sessions from the last 5 days" },
     { key: "timeline", label: "Timeline", icon: "📅", title: "Gantt-style view of session activity over the last 5 days" },
     { key: "files", label: "Files", icon: "📁", title: "Files most frequently edited across recent sessions" },

--- a/frontend/src/state/AppContext.tsx
+++ b/frontend/src/state/AppContext.tsx
@@ -85,6 +85,13 @@ export interface AppState {
   notificationsEnabled: boolean;
   consecutiveFailures: number;
   lastFetchedAt: number | null;
+  /**
+   * True once the first full session list has been fetched. Distinct from
+   * `lastFetchedAt`, which is also set by the fast process-only poll — using
+   * that for the initial loading guard caused a flash of the empty state when
+   * the process poll won the race against the slower first session fetch.
+   */
+  sessionsLoaded: boolean;
   serverPid: number | null;
   /** True while a version update is in progress. */
   updating: boolean;
@@ -118,6 +125,7 @@ export function initialState(): AppState {
       Notification.permission === "granted",
     consecutiveFailures: 0,
     lastFetchedAt: null,
+    sessionsLoaded: false,
     serverPid: null,
     updating: false,
     updateTarget: null,
@@ -151,7 +159,7 @@ export type Action =
 export function appReducer(state: AppState, action: Action): AppState {
   switch (action.type) {
     case "SET_SESSIONS":
-      return { ...state, sessions: action.sessions };
+      return { ...state, sessions: action.sessions, sessionsLoaded: true };
 
     case "SET_REMOTE_SESSIONS":
       return { ...state, remoteSessions: action.sessions };

--- a/frontend/src/test/components.test.tsx
+++ b/frontend/src/test/components.test.tsx
@@ -4,8 +4,9 @@
 
 import { render, screen, fireEvent, act, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { useEffect } from "react";
 import type { Session, ProcessInfo, ProcessMap } from "../types";
-import { AppProvider } from "../state";
+import { AppProvider, useAppDispatch } from "../state";
 
 // ── Factories ────────────────────────────────────────────────────────────────
 
@@ -93,6 +94,25 @@ beforeEach(() => {
 
 function renderWithProvider(ui: React.ReactElement) {
   return render(<AppProvider>{ui}</AppProvider>);
+}
+
+// Seeds `sessionsLoaded: true` (via an empty SET_SESSIONS) so components render
+// their post-load empty state instead of the initial "Loading sessions…" guard.
+function SeedSessionsLoaded() {
+  const dispatch = useAppDispatch();
+  useEffect(() => {
+    dispatch({ type: "SET_SESSIONS", sessions: [] });
+  }, [dispatch]);
+  return null;
+}
+
+function renderLoaded(ui: React.ReactElement) {
+  return render(
+    <AppProvider>
+      <SeedSessionsLoaded />
+      {ui}
+    </AppProvider>,
+  );
 }
 
 // ── SessionCard ──────────────────────────────────────────────────────────────
@@ -323,13 +343,18 @@ describe("SessionTile", () => {
     expect(starBtn.textContent).toBe("⭐");
   });
 
-  it("does not show window_title when it matches intent", () => {
+  it("shows the window title in the focus button tooltip", () => {
     const s = makeSession({ intent: "Fixing auth" });
-    const p = makeProcess({ window_title: "🤖 Fixing auth" });
+    const p = makeProcess({ window_title: "Terminal — Fixing auth" });
     const { container } = renderWithProvider(
       <SessionTile session={s} processInfo={p} onOpenDetail={onOpenDetail} />,
     );
+    // The window title is no longer a standalone subtitle line...
     expect(container.querySelector("[data-tip^='Window:']")).toBeNull();
+    // ...it is surfaced via the focus (🪟) button's tooltip instead.
+    expect(
+      container.querySelector("[data-tip='Focus window: Terminal — Fixing auth']"),
+    ).not.toBeNull();
   });
 });
 
@@ -347,7 +372,7 @@ describe("SessionList", () => {
   });
 
   it("renders empty message for previous when no sessions", () => {
-    renderWithProvider(
+    renderLoaded(
       <SessionList sessions={[]} processes={{}} isActive={false} panelId="previous" />,
     );
     expect(screen.getByText("No previous sessions.")).toBeInTheDocument();
@@ -384,14 +409,22 @@ describe("SessionList", () => {
 import StatsRow from "../components/StatsRow";
 
 describe("StatsRow", () => {
-  it("returns null when no active sessions", () => {
-    const { container } = render(<StatsRow active={[]} processes={{}} />);
+  it("returns null when loaded with no active sessions", () => {
+    const { container } = renderLoaded(<StatsRow active={[]} processes={{}} />);
     expect(container.innerHTML).toBe("");
+  });
+
+  it("shows spinners (aria-busy) while sessions are still loading", () => {
+    // No seeder → sessionsLoaded stays false → loading state.
+    const { container } = renderWithProvider(<StatsRow active={[]} processes={{}} />);
+    expect(container.querySelector(".stats-row[aria-busy='true']")).not.toBeNull();
+    expect(container.querySelectorAll(".stat-spinner").length).toBe(5);
+    expect(screen.getByText("Running Now")).toBeInTheDocument();
   });
 
   it("renders running count", () => {
     const active = [makeSession({ id: "a" }), makeSession({ id: "b" })];
-    render(<StatsRow active={active} processes={{}} />);
+    renderLoaded(<StatsRow active={active} processes={{}} />);
     expect(screen.getByText("2")).toBeInTheDocument();
     expect(screen.getByText("Running Now")).toBeInTheDocument();
   });
@@ -401,7 +434,7 @@ describe("StatsRow", () => {
       makeSession({ id: "a", turn_count: 10 }),
       makeSession({ id: "b", turn_count: 20 }),
     ];
-    render(<StatsRow active={active} processes={{}} />);
+    renderLoaded(<StatsRow active={active} processes={{}} />);
     expect(screen.getByText("30")).toBeInTheDocument();
   });
 
@@ -410,7 +443,7 @@ describe("StatsRow", () => {
       makeSession({ id: "a", tool_calls: 5 }),
       makeSession({ id: "b", tool_calls: 15 }),
     ];
-    render(<StatsRow active={active} processes={{}} />);
+    renderLoaded(<StatsRow active={active} processes={{}} />);
     expect(screen.getByText("20")).toBeInTheDocument();
   });
 
@@ -419,7 +452,7 @@ describe("StatsRow", () => {
       makeSession({ id: "a", subagent_runs: 3, turn_count: 0, tool_calls: 0 }),
       makeSession({ id: "b", subagent_runs: 7, turn_count: 0, tool_calls: 0 }),
     ];
-    render(<StatsRow active={active} processes={{}} />);
+    renderLoaded(<StatsRow active={active} processes={{}} />);
     expect(screen.getByText("Sub-agents")).toBeInTheDocument();
     expect(screen.getAllByText("10")).toHaveLength(1);
   });
@@ -430,7 +463,7 @@ describe("StatsRow", () => {
       a: makeProcess({ bg_tasks: 2 }),
       b: makeProcess({ bg_tasks: 3 }),
     };
-    render(<StatsRow active={active} processes={processes} />);
+    renderLoaded(<StatsRow active={active} processes={processes} />);
     expect(screen.getByText("5")).toBeInTheDocument();
     expect(screen.getByText("Background Tasks")).toBeInTheDocument();
   });
@@ -810,7 +843,7 @@ describe("SessionTile — interactions", () => {
     renderWithProvider(
       <SessionTile session={s} processInfo={p} onOpenDetail={onOpenDetail} />,
     );
-    expect(screen.getByText("👁️")).toBeInTheDocument();
+    expect(screen.getByText("🪟")).toBeInTheDocument();
   });
 
   it("shows bg_tasks badge when background tasks exist", () => {
@@ -1311,8 +1344,18 @@ describe("SessionGrid", () => {
   });
 
   it("renders empty message for previous when no sessions", () => {
-    renderWithProvider(<SessionGrid sessions={[]} processes={{}} isActive={false} />);
+    renderLoaded(<SessionGrid sessions={[]} processes={{}} isActive={false} />);
     expect(screen.getByText("No previous sessions.")).toBeInTheDocument();
+  });
+
+  it("shows the empty (not loading) state for active once sessions have loaded", () => {
+    // Regression: the fast process-only poll used to flip the loading guard
+    // before the first session fetch resolved, flashing the empty state. The
+    // loading guard now keys off `sessionsLoaded`, so an empty-but-loaded active
+    // list shows the empty message and never "Loading sessions…".
+    renderLoaded(<SessionGrid sessions={[]} processes={{}} isActive={true} />);
+    expect(screen.getByText("No active sessions detected.")).toBeInTheDocument();
+    expect(screen.queryByText("Loading sessions…")).toBeNull();
   });
 
   it("renders tiles for sessions", () => {

--- a/frontend/src/themes.css
+++ b/frontend/src/themes.css
@@ -290,7 +290,7 @@ button.hamburger-item {
   background: var(--surface); border: 1px solid var(--border); border-radius: 8px;
   padding: 14px; text-align: center;
 }
-.stat-card .num { font-size: 30px; font-weight: 700; color: var(--accent); }
+.stat-card .num { font-size: 30px; font-weight: 700; color: var(--accent); line-height: 1.25; }
 .stat-card .label { font-size: 13px; color: var(--text2); text-transform: uppercase; letter-spacing: 0.5px; }
 
 /* ===== TABS ===== */
@@ -305,6 +305,9 @@ button.hamburger-item {
 .tab .count {
   background: var(--surface2); border-radius: 10px; padding: 2px 8px;
   font-size: 13px; margin-left: 6px;
+  display: inline-block; box-sizing: border-box;
+  min-width: 30px; text-align: center;
+  font-variant-numeric: tabular-nums;
 }
 .tab.active .count { background: rgba(88,166,255,0.15); color: var(--accent); }
 
@@ -458,7 +461,32 @@ button.hamburger-item {
   border-radius: 3px; padding: 2px 8px; color: var(--green);
 }
 .empty { color: var(--text2); font-style: italic; font-size: 14px; padding: 12px 0; }
-.loading { text-align: center; padding: 30px; color: var(--text2); }
+.loading {
+  text-align: center; padding: 40px 30px; color: var(--text2);
+  display: flex; flex-direction: column; align-items: center; gap: 14px;
+}
+
+/* Reusable spinning ring. Size/border scale via font-size using em units. */
+.spinner {
+  width: 2.2em; height: 2.2em;
+  border: 0.22em solid var(--border);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+@keyframes spin { to { transform: rotate(360deg); } }
+
+/* Spinner shown in place of a stat number while data loads. Its box height
+   matches `.stat-card .num` (30px * 1.25 line-height = 37.5px) so swapping the
+   spinner for the real number causes no vertical layout shift. */
+.stat-spinner {
+  height: 37.5px;
+  display: flex; justify-content: center; align-items: center;
+}
+.stat-spinner .spinner { width: 30px; height: 30px; border-width: 3px; }
+@media (prefers-reduced-motion: reduce) {
+  .spinner { animation-duration: 2s; }
+}
 
 /* ===== MODAL ===== */
 .modal-overlay {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,8 +1,29 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
+// Dev-only: inject the API token into index.html so the HMR frontend (served by
+// Vite, not the backend) can authenticate against a locally-run backend. Set the
+// same value on the backend via the AGENTEYE_API_TOKEN env var. Defaults to
+// "dev-token" so `npm run dev` + `AGENTEYE_API_TOKEN=dev-token <backend>` works.
+const devToken = process.env.AGENTEYE_API_TOKEN || "dev-token";
+
 export default defineConfig({
-  plugins: [react()],
+  plugins: [
+    react(),
+    {
+      name: "inject-dev-token",
+      apply: "serve",
+      transformIndexHtml() {
+        return [
+          {
+            tag: "script",
+            injectTo: "head-prepend",
+            children: `window.__DASHBOARD_TOKEN__=${JSON.stringify(devToken)};`,
+          },
+        ];
+      },
+    },
+  ],
   build: {
     outDir: "../src/static/dist",
     emptyOutDir: true,
@@ -12,6 +33,7 @@ export default defineConfig({
     port: 5173,
     proxy: {
       "/api": "http://localhost:5112",
+      "/static": "http://localhost:5112",
       "/favicon.png": "http://localhost:5112",
       "/manifest.json": "http://localhost:5112",
       "/sw.js": "http://localhost:5112",

--- a/src/dashboard_api.py
+++ b/src/dashboard_api.py
@@ -187,8 +187,30 @@ app = FastAPI(
 
 # ── Security ─────────────────────────────────────────────────────────────────
 
+
 # Per-instance token generated at startup; required on all /api/* requests.
-API_TOKEN: str = secrets.token_urlsafe(32)
+#
+# In normal/production use this is a fresh random token unique to each process,
+# which is injected into the served HTML so only the same-origin frontend can
+# call the API.
+#
+# For local development, the Vite dev server serves its *own* index.html (so it
+# can't receive the injected token) and instead injects a fixed token of its
+# own. To let that dev frontend authenticate, we allow the token to be overridden
+# via the AGENTEYE_API_TOKEN env var — but ONLY when running from a source
+# checkout (i.e. a ".git" directory exists at the repo root). A pip-installed
+# production instance has no ".git", so it always ignores the env var and uses a
+# random token. This means an AGENTEYE_API_TOKEN exported in the environment can
+# never weaken a real deployment.
+def _running_from_source_checkout() -> bool:
+    """True when running from a dev git checkout (parent of the package dir
+    contains a ``.git`` directory), False for a pip-installed package."""
+    repo_root = os.path.dirname(PKG_DIR)
+    return os.path.isdir(os.path.join(repo_root, ".git"))
+
+
+_token_override = os.environ.get("AGENTEYE_API_TOKEN") if _running_from_source_checkout() else None
+API_TOKEN: str = _token_override or secrets.token_urlsafe(32)
 
 # CORS: only allow same-origin requests (no cross-origin API access)
 app.add_middleware(
@@ -918,6 +940,16 @@ def api_update(request: Request):
     port = str(server[1]) if server and len(server) >= 2 else "5111"
     server_pid = os.getpid()
 
+    # Restart in the same mode the process was launched in (see LAUNCH_MODE),
+    # mirroring the autostart logic. Started via `agenteye app` (tray app with
+    # window)? Relaunch the tray app so the systray icon returns. Otherwise
+    # relaunch the lighter headless background server. Without this, an in-app
+    # update from the tray app would restart headless and the icon would vanish.
+    if LAUNCH_MODE == "app":
+        restart_args = ["app", "--hidden", "--port", port]
+    else:
+        restart_args = ["start", "--background", "--port", port]
+
     script_lines = [
         "import subprocess, sys, os, signal, time, shutil",
         "time.sleep(2)",
@@ -942,7 +974,7 @@ def api_update(request: Request):
         "        kw['creationflags'] = subprocess.CREATE_NO_WINDOW | 0x8",
         "    else:",
         "        kw['start_new_session'] = True",
-        f"    subprocess.Popen([cmd, 'start', '--background', '--port', '{port}'], **kw)",
+        f"    subprocess.Popen([cmd, *{restart_args!r}], **kw)",
     ]
     script = "\n".join(script_lines)
 

--- a/tests/test_version_update.py
+++ b/tests/test_version_update.py
@@ -45,7 +45,9 @@ def _make_pypi_response(version: str, releases: dict | None = None) -> MagicMock
 
 class TestApiVersion:
     def test_returns_current_version(self, client):
-        with patch("src.dashboard_api.urllib.request.urlopen", return_value=_make_pypi_response("99.0.0")):
+        with patch(
+            "src.dashboard_api.urllib.request.urlopen", return_value=_make_pypi_response("99.0.0")
+        ):
             resp = client.get("/api/version")
         assert resp.status_code == 200
         data = resp.json()
@@ -55,33 +57,43 @@ class TestApiVersion:
 
     def test_no_update_when_same_version(self, client):
         current = dashboard_api.__version__
-        with patch("src.dashboard_api.urllib.request.urlopen", return_value=_make_pypi_response(current)):
+        with patch(
+            "src.dashboard_api.urllib.request.urlopen", return_value=_make_pypi_response(current)
+        ):
             resp = client.get("/api/version")
         data = resp.json()
         assert data["update_available"] is False
         assert data["latest"] == current
 
     def test_uses_cache_on_second_call(self, client):
-        with patch("src.dashboard_api.urllib.request.urlopen", return_value=_make_pypi_response("5.0.0")) as mock_urlopen:
+        with patch(
+            "src.dashboard_api.urllib.request.urlopen", return_value=_make_pypi_response("5.0.0")
+        ) as mock_urlopen:
             client.get("/api/version")
             client.get("/api/version")
         # PyPI should only be hit once; second call served from cache
         assert mock_urlopen.call_count == 1
 
     def test_cache_expires_after_ttl(self, client):
-        with patch("src.dashboard_api.urllib.request.urlopen", return_value=_make_pypi_response("5.0.0")):
+        with patch(
+            "src.dashboard_api.urllib.request.urlopen", return_value=_make_pypi_response("5.0.0")
+        ):
             client.get("/api/version")
 
         # Force the cache to appear expired by backdating checked_at beyond the TTL
         _version_cache.checked_at = time.monotonic() - dashboard_api.VERSION_CACHE_TTL - 1
 
-        with patch("src.dashboard_api.urllib.request.urlopen", return_value=_make_pypi_response("6.0.0")) as mock2:
+        with patch(
+            "src.dashboard_api.urllib.request.urlopen", return_value=_make_pypi_response("6.0.0")
+        ) as mock2:
             resp = client.get("/api/version")
         assert mock2.call_count == 1
         assert resp.json()["latest"] == "6.0.0"
 
     def test_pypi_failure_returns_current(self, client):
-        with patch("src.dashboard_api.urllib.request.urlopen", side_effect=Exception("network error")):
+        with patch(
+            "src.dashboard_api.urllib.request.urlopen", side_effect=Exception("network error")
+        ):
             resp = client.get("/api/version")
         assert resp.status_code == 200
         data = resp.json()
@@ -91,13 +103,17 @@ class TestApiVersion:
     def test_pypi_timeout_returns_current(self, client):
         import urllib.error
 
-        with patch("src.dashboard_api.urllib.request.urlopen", side_effect=urllib.error.URLError("timeout")):
+        with patch(
+            "src.dashboard_api.urllib.request.urlopen", side_effect=urllib.error.URLError("timeout")
+        ):
             resp = client.get("/api/version")
         data = resp.json()
         assert data["update_available"] is False
 
     def test_response_shape(self, client):
-        with patch("src.dashboard_api.urllib.request.urlopen", return_value=_make_pypi_response("1.2.3")):
+        with patch(
+            "src.dashboard_api.urllib.request.urlopen", return_value=_make_pypi_response("1.2.3")
+        ):
             resp = client.get("/api/version")
         data = resp.json()
         assert "current" in data
@@ -145,6 +161,27 @@ class TestApiUpdate:
         script = mock_popen.call_args[0][0][2]
         assert "start" in script
         assert "--port" in script
+
+    def test_restart_uses_server_mode_by_default(self, client):
+        with patch("src.dashboard_api.subprocess.Popen") as mock_popen:
+            with patch.object(dashboard_api, "LAUNCH_MODE", "server"):
+                client.post("/api/update")
+        script = mock_popen.call_args[0][0][2]
+        # Headless background server restart
+        assert "'start'" in script
+        assert "'--background'" in script
+        assert "'app'" not in script
+
+    def test_restart_uses_app_mode_when_launched_as_tray(self, client):
+        """Regression: an in-app update from the tray app must relaunch the tray
+        app (so the systray icon returns), not the headless server."""
+        with patch("src.dashboard_api.subprocess.Popen") as mock_popen:
+            with patch.object(dashboard_api, "LAUNCH_MODE", "app"):
+                client.post("/api/update")
+        script = mock_popen.call_args[0][0][2]
+        assert "'app'" in script
+        assert "'--hidden'" in script
+        assert "'--background'" not in script
 
     def test_windows_uses_detached_flags(self, client):
         with (


### PR DESCRIPTION
## Summary
Fixes the in-app update restart bug and several dashboard loading/UX issues.

### Backend
- **In-app update restart mode** (`api_update`): relaunch in the same mode the process was started in (via `LAUNCH_MODE`). Previously an in-app update from the tray app always restarted `start --background` (headless), so the **systray icon never came back**. Now it relaunches `app --hidden` when running as the tray app.
- **Dev token override**: `AGENTEYE_API_TOKEN` is honored **only** when running from a source checkout (`.git` present). A pip-installed production instance always ignores it and uses a random per-instance token, so this can never weaken a real deployment.

### Dev workflow (Vite HMR)
- Proxy `/static` and inject the dev token in `vite.config.ts` so the logo renders and API calls authenticate in `npm run dev`.

### Frontend UX
- **"No sessions" flash fix**: the initial loading guard now keys off a new `sessionsLoaded` flag (set by `SET_SESSIONS`) instead of `lastFetchedAt`, which the 1s process-only poll set early — racing the slower first session fetch and flashing the empty state. Loading now shows a spinner.
- **StatsRow**: shows spinners (matching card height/layout, no jump) while sessions load, instead of hiding or flashing zeros.
- **SessionTile**: removed the window-title line that crowded the title down to `C...`; the focus button is now a 🪟 glyph whose tooltip is the window title.
- **TabBar**: fixed-width tabular count badge so tabs don't shift when Active/Previous counts change; reworded the Active tab tooltip.

## Testing
- `ruff check src/`, `ruff format --check src/` — clean
- `mypy src/dashboard_api.py` — clean (pre-existing unrelated `getuid` errors in `session_dashboard.py` untouched)
- Frontend `npm run lint`, `npm run typecheck` — clean
- `pytest tests/test_version_update.py` — 15 passed
- Frontend `vitest` — 238 passed