### PR TITLE
Add repository-specific Puppets instructions

### DIFF
--- a/.github/puppets/curation.md
+++ b/.github/puppets/curation.md
@@ -1,0 +1,7 @@
+# AgentEye curation instructions
+
+- Check for duplicates and overlap with existing issues and pull requests before proposing implementation.
+- Keep each implementation scoped to one independently testable change. Split broad work into linked child issues.
+- Prefer existing modules and typed models described in `DEVELOPMENT.md`; avoid parallel abstractions.
+- Flag changes that expose local session data, weaken process-safety checks, alter destructive defaults, or require credentials as `needs-human`.
+- Preserve cross-platform behavior unless the approved issue explicitly scopes the change to one operating system.

--- a/.github/puppets/implementation.md
+++ b/.github/puppets/implementation.md
@@ -1,0 +1,10 @@
+# AgentEye implementation instructions
+
+- Follow `.github/copilot-instructions.md` and `DEVELOPMENT.md`; the approved issue and its acceptance criteria define the requested behavior.
+- Reuse existing CLI, typed-model, API, frontend, and packaging patterns before introducing new abstractions.
+- Keep platform-specific behavior behind explicit platform checks and preserve current behavior on other operating systems.
+- Treat session databases, event logs, filesystem paths, process information, and configuration as sensitive local data. Do not add telemetry or transmit them externally.
+- Add focused tests for new behavior and failure cases. For filesystem or platform integration, use temporary paths and mocks rather than changing the runner machine.
+- Run the repository checks relevant to touched code. Python changes must satisfy Ruff, MyPy, and pytest; frontend changes must satisfy lint, typecheck, tests, and build.
+- Update user-facing documentation for new commands, settings, installation behavior, limitations, or platform requirements.
+- Do not merge, publish, release, or broaden the issue scope.

--- a/.github/puppets/review.md
+++ b/.github/puppets/review.md
@@ -1,0 +1,8 @@
+# AgentEye review instructions
+
+- Review against every acceptance criterion in the approved issue and identify any criterion without implementation or test evidence.
+- Require focused regression tests, clear errors, idempotency where promised, and safe handling of user files and processes.
+- Check that platform-specific changes preserve behavior on unsupported or unaffected operating systems.
+- Reject new transmission of session data, local paths, process details, or configuration unless explicitly approved.
+- Confirm Python and frontend checks appropriate to the diff are represented in CI.
+- Treat release, publishing, auto-merge, and unrelated refactors as out of scope.

--- a/.github/puppets/triage.md
+++ b/.github/puppets/triage.md
@@ -1,0 +1,7 @@
+# AgentEye triage instructions
+
+- Classify the issue as Python backend/CLI, React frontend, packaging/release, documentation, or cross-cutting.
+- Require enough detail to identify the affected command or UI, target operating system, expected behavior, and actual behavior.
+- For platform-specific work, state which behavior must remain unchanged on Windows, macOS, and Linux.
+- Treat local session content, paths, process details, and configuration as sensitive user data.
+- Do not infer approval from priority, labels other than `puppets:approved`, or issue wording.


### PR DESCRIPTION
Add trusted, versioned instructions for Puppets triage, curation, implementation, and review. The central automation currently consumes `implementation.md`; the remaining files establish guidance for later stages.