### PR TITLE
Add repository-owned Puppets caller

### DIFF
--- a/.github/workflows/puppets.yml
+++ b/.github/workflows/puppets.yml
@@ -1,0 +1,33 @@
+name: Puppets
+
+on:
+  schedule:
+    - cron: "30 16 * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Report intended mutations without applying them
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  group: puppets-${{ github.repository }}
+  cancel-in-progress: false
+
+permissions:
+  actions: write
+  contents: write
+  id-token: write
+  issues: write
+  pull-requests: write
+  copilot-requests: write
+
+jobs:
+  reconcile:
+    uses: JeffSteinbok/puppets/.github/workflows/reconcile.yml@e4d85e333ebbb42c0f4dd20b7860fa7882e90a2e
+    with:
+      dry_run: ${{ inputs.dry_run || false }}
+      caller_workflow: puppets.yml
+    secrets:
+      token: ${{ secrets.PAT_TOKEN }}

--- a/.puppets/config.json
+++ b/.puppets/config.json
@@ -1,0 +1,7 @@
+{
+  "version": 1,
+  "approvalActors": [
+    "JeffSteinbok",
+    "jeffsteinbok-openclaw"
+  ]
+}


### PR DESCRIPTION
Adds the local Puppets caller and trusted configuration, using a staggered daily schedule and immutable framework commit.